### PR TITLE
feat: 커서 페이지네이션 이용한 피드 전체리스트 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,18 @@ dependencies {
     // AWS
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
     implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
+
+    //Querydsl 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+clean {
+    delete file('src/main/generated')
 }

--- a/src/main/java/com/listywave/common/config/EnumMappingConfig.java
+++ b/src/main/java/com/listywave/common/config/EnumMappingConfig.java
@@ -1,0 +1,15 @@
+package com.listywave.common.config;
+
+import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class EnumMappingConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        ApplicationConversionService.configure(registry);
+    }
+}

--- a/src/main/java/com/listywave/common/config/QuerydslConfig.java
+++ b/src/main/java/com/listywave/common/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package com.listywave.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em){
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/listywave/list/application/domain/CategoryType.java
+++ b/src/main/java/com/listywave/list/application/domain/CategoryType.java
@@ -1,5 +1,8 @@
 package com.listywave.list.application.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.listywave.common.exception.CustomException;
+import com.listywave.common.exception.ErrorCode;
 import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,24 +11,35 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum CategoryType {
 
-    ENTIRE("1","ENTIRE","전체"),
-    CULTURE("2","CULTURE","문화"),
-    LIFE("3","LIFE","일상생활"),
-    PLACE("4","PLACE","장소"),
-    MUSIC("5","MUSIC","음악"),
-    MOVIE_DRAMA("6","MOVIE_DRAMA","영화/드라마"),
-    BOOK("7","BOOK","도서"),
-    ANIMAL_PLANT("8","ANIMAL_PLANT","동식물"),
-    ETC("9","ETC","기타"),
+    ENTIRE("0","전체"),
+    CULTURE("1","문화"),
+    LIFE("2","일상생활"),
+    PLACE("3","장소"),
+    MUSIC("4","음악"),
+    MOVIE_DRAMA("5","영화/드라마"),
+    BOOK("6","도서"),
+    ANIMAL_PLANT("7","동식물"),
+    ETC("8","기타"),
     ;
 
     private final String codeValue;
-    private final String nameValue;
     private final String korNameValue;
 
     public static CategoryType enumOf(String codeValue) {
         return Arrays.stream(CategoryType.values())
                 .filter( t -> t.getCodeValue().equals(codeValue))
-                .findAny().orElse(null);
+                .findAny().orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당 카테고리코드는 존재하지 않습니다."));
     }
+
+    @JsonCreator
+    public static CategoryType fromString(String key) {
+        for(CategoryType category : CategoryType.values()) {
+            if(category.name().equalsIgnoreCase(key)) {
+                return category;
+            }
+        }
+        throw new CustomException(ErrorCode.NOT_FOUND, "해당 카테고리는 존재하지 않습니다.");
+    }
+
+
 }

--- a/src/main/java/com/listywave/list/application/domain/CategoryType.java
+++ b/src/main/java/com/listywave/list/application/domain/CategoryType.java
@@ -11,15 +11,15 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum CategoryType {
 
-    ENTIRE("0","전체"),
-    CULTURE("1","문화"),
-    LIFE("2","일상생활"),
-    PLACE("3","장소"),
-    MUSIC("4","음악"),
-    MOVIE_DRAMA("5","영화/드라마"),
-    BOOK("6","도서"),
-    ANIMAL_PLANT("7","동식물"),
-    ETC("8","기타"),
+    ENTIRE("0", "전체"),
+    CULTURE("1", "문화"),
+    LIFE("2", "일상생활"),
+    PLACE("3", "장소"),
+    MUSIC("4", "음악"),
+    MOVIE_DRAMA("5", "영화/드라마"),
+    BOOK("6", "도서"),
+    ANIMAL_PLANT("7", "동식물"),
+    ETC("8", "기타"),
     ;
 
     private final String codeValue;
@@ -27,19 +27,16 @@ public enum CategoryType {
 
     public static CategoryType enumOf(String codeValue) {
         return Arrays.stream(CategoryType.values())
-                .filter( t -> t.getCodeValue().equals(codeValue))
-                .findAny().orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당 카테고리코드는 존재하지 않습니다."));
+                .filter(t -> t.getCodeValue().equals(codeValue))
+                .findAny()
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당 카테고리코드는 존재하지 않습니다."));
     }
 
     @JsonCreator
     public static CategoryType fromString(String key) {
-        for(CategoryType category : CategoryType.values()) {
-            if(category.name().equalsIgnoreCase(key)) {
-                return category;
-            }
-        }
-        throw new CustomException(ErrorCode.NOT_FOUND, "해당 카테고리는 존재하지 않습니다.");
+        return Arrays.stream(CategoryType.values())
+                .filter(categoryType -> categoryType.name().equalsIgnoreCase(key))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당 카테고리는 존재하지 않습니다."));
     }
-
-
 }

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -5,8 +5,8 @@ import com.listywave.collaborator.domain.repository.CollaboratorRepository;
 import com.listywave.common.exception.CustomException;
 import com.listywave.common.exception.ErrorCode;
 import com.listywave.common.util.UserUtil;
-import com.listywave.list.application.dto.ListCreateCommand;
 import com.listywave.list.application.domain.Lists;
+import com.listywave.list.application.dto.ListCreateCommand;
 import com.listywave.list.presentation.dto.request.ItemCreateRequest;
 import com.listywave.list.presentation.dto.response.ListCreateResponse;
 import com.listywave.list.repository.ListRepository;
@@ -41,7 +41,7 @@ public class ListService {
 
         Boolean isLabels = isLabelCountValid(labels);
         validateItemsCount(items);
-        Boolean hasCollaboratorId = hascollaboratorExistence(collaboratorIds);
+        Boolean hasCollaboratorId = isExistCollaborator(collaboratorIds);
 
         Lists list = Lists.createList(
                 user,
@@ -53,14 +53,14 @@ public class ListService {
         );
         listRepository.save(list);
 
-       if(hasCollaboratorId){
-           List<User> users = findExistingCollaborators(collaboratorIds);
+        if (hasCollaboratorId) {
+            List<User> users = findExistingCollaborators(collaboratorIds);
 
             List<Collaborator> collaborators = users.stream()
                     .map(u -> Collaborator.createCollaborator(u, list))
                     .collect(Collectors.toList());
             collaboratorRepository.saveAll(collaborators);
-       }
+        }
         return ListCreateResponse.of(list.getId());
     }
 
@@ -70,7 +70,7 @@ public class ListService {
         List<Long> nonExistingIds = collaboratorIds.stream()
                 .filter(
                         id -> existingCollaborators.stream()
-                                            .noneMatch(user -> user.getId().equals(id))
+                                .noneMatch(user -> user.getId().equals(id))
                 )
                 .toList();
 
@@ -80,24 +80,24 @@ public class ListService {
         return existingCollaborators;
     }
 
-    private Boolean hascollaboratorExistence(List<Long> collaboratorIds) {
-        if(collaboratorIds != null && collaboratorIds.size() > 20){
+    private Boolean isExistCollaborator(List<Long> collaboratorIds) {
+        if (collaboratorIds != null && collaboratorIds.size() > 20) {
             throw new CustomException(ErrorCode.INVALID_COUNT, "콜라보레이터는 최대 20명까지 가능합니다.");
         }
         return collaboratorIds != null && !collaboratorIds.isEmpty();
     }
 
     private void validateItemsCount(List<ItemCreateRequest> items) {
-        if(items.size() < 3 || items.size() > 10){
+        if (items.size() < 3 || items.size() > 10) {
             throw new CustomException(ErrorCode.INVALID_COUNT, "아이템의 개수는 3개에서 10개까지 가능합니다.");
         }
     }
 
     private Boolean isLabelCountValid(List<String> labels) {
-        if(labels == null || labels.isEmpty()){
+        if (labels == null || labels.isEmpty()) {
             return false;
         }
-        if(labels.size() > 3){
+        if (labels.size() > 3) {
             throw new CustomException(ErrorCode.INVALID_COUNT, "라벨의 개수는 최대 3개까지 작성 가능합니다.");
         }
         return true;

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -81,6 +81,9 @@ public class ListService {
     }
 
     private Boolean hascollaboratorExistence(List<Long> collaboratorIds) {
+        if(collaboratorIds != null && collaboratorIds.size() > 20){
+            throw new CustomException(ErrorCode.INVALID_COUNT, "콜라보레이터는 최대 20명까지 가능합니다.");
+        }
         return collaboratorIds != null && !collaboratorIds.isEmpty();
     }
 

--- a/src/main/java/com/listywave/list/presentation/dto/response/CategoryTypeResponse.java
+++ b/src/main/java/com/listywave/list/presentation/dto/response/CategoryTypeResponse.java
@@ -11,7 +11,7 @@ public record CategoryTypeResponse(
     public static CategoryTypeResponse fromEnum(CategoryType categoryType) {
         return new CategoryTypeResponse(
             categoryType.getCodeValue(),
-            categoryType.getNameValue(),
+            categoryType.name().toLowerCase(),
             categoryType.getKorNameValue()
         );
     }

--- a/src/main/java/com/listywave/user/application/dto/FeedListsDto.java
+++ b/src/main/java/com/listywave/user/application/dto/FeedListsDto.java
@@ -1,0 +1,41 @@
+package com.listywave.user.application.dto;
+
+import com.listywave.list.application.domain.Item;
+import com.listywave.list.application.domain.Lists;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record FeedListsDto(
+        Long id,
+        String title,
+        Boolean isPublic,
+        List<ListItemsDto> listItems
+) {
+    public static FeedListsDto of(Lists lists){
+        return new FeedListsDto(
+                lists.getId(),
+                lists.getTitle().getValue(),
+                lists.isPublic(),
+                lists.getItems().stream()
+                        .map(ListItemsDto::of)
+                        .collect(Collectors.toList())
+        );
+    }
+}
+
+record ListItemsDto(
+        Long id,
+        int ranking,
+        String title,
+        String imageUrl
+){
+    public static ListItemsDto of(Item item){
+        return new ListItemsDto(
+                item.getId(),
+                item.getRanking(),
+                item.getTitle().getValue(),
+                item.getImageUrl().getValue()
+        );
+    }
+
+}

--- a/src/main/java/com/listywave/user/application/dto/FeedListsDto.java
+++ b/src/main/java/com/listywave/user/application/dto/FeedListsDto.java
@@ -11,10 +11,10 @@ public record FeedListsDto(
         Boolean isPublic,
         List<ListItemsDto> listItems
 ) {
-    public static FeedListsDto of(Lists lists){
+    public static FeedListsDto of(Lists lists) {
         return new FeedListsDto(
                 lists.getId(),
-                lists.getTitle().getValue(),
+                lists.getTitle(),
                 lists.isPublic(),
                 lists.getItems().stream()
                         .map(ListItemsDto::of)
@@ -28,13 +28,13 @@ record ListItemsDto(
         int ranking,
         String title,
         String imageUrl
-){
-    public static ListItemsDto of(Item item){
+) {
+    public static ListItemsDto of(Item item) {
         return new ListItemsDto(
                 item.getId(),
                 item.getRanking(),
-                item.getTitle().getValue(),
-                item.getImageUrl().getValue()
+                item.getTitle(),
+                item.getImageUrl()
         );
     }
 

--- a/src/main/java/com/listywave/user/application/dto/FeedListsResponse.java
+++ b/src/main/java/com/listywave/user/application/dto/FeedListsResponse.java
@@ -20,7 +20,6 @@ public record FeedListsResponse(
                 .isPublic(lists.isPublic())
                 .listItems(ListItemsResponse.toList(lists))
                 .build();
-
     }
 }
 

--- a/src/main/java/com/listywave/user/application/dto/FeedListsResponse.java
+++ b/src/main/java/com/listywave/user/application/dto/FeedListsResponse.java
@@ -5,32 +5,32 @@ import com.listywave.list.application.domain.Lists;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public record FeedListsDto(
+public record FeedListsResponse(
         Long id,
         String title,
         Boolean isPublic,
-        List<ListItemsDto> listItems
+        List<ListItemsResponse> listItems
 ) {
-    public static FeedListsDto of(Lists lists){
-        return new FeedListsDto(
+    public static FeedListsResponse of(Lists lists) {
+        return new FeedListsResponse(
                 lists.getId(),
                 lists.getTitle().getValue(),
                 lists.isPublic(),
                 lists.getItems().stream()
-                        .map(ListItemsDto::of)
+                        .map(ListItemsResponse::of)
                         .collect(Collectors.toList())
         );
     }
 }
 
-record ListItemsDto(
+record ListItemsResponse(
         Long id,
         int ranking,
         String title,
         String imageUrl
-){
-    public static ListItemsDto of(Item item){
-        return new ListItemsDto(
+) {
+    public static ListItemsResponse of(Item item) {
+        return new ListItemsResponse(
                 item.getId(),
                 item.getRanking(),
                 item.getTitle().getValue(),

--- a/src/main/java/com/listywave/user/application/dto/FeedListsResponse.java
+++ b/src/main/java/com/listywave/user/application/dto/FeedListsResponse.java
@@ -4,7 +4,9 @@ import com.listywave.list.application.domain.Item;
 import com.listywave.list.application.domain.Lists;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Builder;
 
+@Builder
 public record FeedListsResponse(
         Long id,
         String title,
@@ -12,17 +14,17 @@ public record FeedListsResponse(
         List<ListItemsResponse> listItems
 ) {
     public static FeedListsResponse of(Lists lists) {
-        return new FeedListsResponse(
-                lists.getId(),
-                lists.getTitle(),
-                lists.isPublic(),
-                lists.getItems().stream()
-                        .map(ListItemsResponse::of)
-                        .collect(Collectors.toList())
-        );
+        return FeedListsResponse.builder()
+                .id(lists.getId())
+                .title(lists.getTitle())
+                .isPublic(lists.isPublic())
+                .listItems(ListItemsResponse.toList(lists))
+                .build();
+
     }
 }
 
+@Builder
 record ListItemsResponse(
         Long id,
         int ranking,
@@ -30,11 +32,17 @@ record ListItemsResponse(
         String imageUrl
 ) {
     public static ListItemsResponse of(Item item) {
-        return new ListItemsResponse(
-                item.getId(),
-                item.getRanking(),
-                item.getTitle(),
-                item.getImageUrl()
-        );
+        return ListItemsResponse.builder()
+                .id(item.getId())
+                .ranking(item.getRanking())
+                .title(item.getTitle())
+                .imageUrl(item.getImageUrl())
+                .build();
+    }
+
+    public static List<ListItemsResponse> toList(Lists lists) {
+        return lists.getItems().stream()
+                .map(ListItemsResponse::of)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -9,7 +9,6 @@ import com.listywave.list.application.domain.CategoryType;
 import com.listywave.list.application.domain.Lists;
 import com.listywave.user.application.domain.User;
 import com.listywave.user.application.dto.AllUserResponse;
-import com.listywave.user.application.dto.FeedListsDto;
 import com.listywave.user.application.dto.UserInfoResponse;
 import com.listywave.user.presentation.dto.response.AllUserListsResponse;
 import com.listywave.user.repository.UserRepository;
@@ -58,21 +57,15 @@ public class UserService {
         boolean hasNext = false;
         cursorId = null;
 
-        if(feedList.size() == size + 1){
+        if (feedList.size() == size + 1) {
             feedList.remove(size);
             hasNext = true;
             cursorId = feedList.get(feedList.size() - 1).getId();
         }
-
-        List<FeedListsDto> collect = feedList.stream()
-                .map(FeedListsDto::of)
-                .toList();
-
-        return AllUserListsResponse.of(hasNext, cursorId, collect);
-
+        return AllUserListsResponse.of(hasNext, cursorId, feedList);
     }
 
-    private static boolean isSignedIn(String accessToken) {
+    private boolean isSignedIn(String accessToken) {
         return accessToken.isBlank();
     }
 

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -42,15 +42,20 @@ public class UserService {
         return UserInfoResponse.of(foundUser, false, false);
     }
 
+
+    private boolean isSignedIn(String accessToken) {
+        return accessToken.isBlank();
+    }
+
     @Transactional(readOnly = true)
-    public AllUserListsResponse getAllUserLists(
+    public AllUserListsResponse getAllListOfUser(
             Long userId,
             String type,
             CategoryType category,
             Long cursorId,
             int size
     ) {
-        User user = userUtil.getUserByUserid(userId);
+        userUtil.getUserByUserid(userId);
 
         List<Lists> feedList = userRepository.findFeedLists(userId, type, category, cursorId, size);
 
@@ -63,10 +68,6 @@ public class UserService {
             cursorId = feedList.get(feedList.size() - 1).getId();
         }
         return AllUserListsResponse.of(hasNext, cursorId, feedList);
-    }
-
-    private boolean isSignedIn(String accessToken) {
-        return accessToken.isBlank();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -4,9 +4,14 @@ import static com.listywave.common.exception.ErrorCode.NOT_FOUND;
 
 import com.listywave.auth.application.domain.JwtManager;
 import com.listywave.common.exception.CustomException;
+import com.listywave.common.util.UserUtil;
+import com.listywave.list.application.domain.CategoryType;
+import com.listywave.list.application.domain.Lists;
 import com.listywave.user.application.domain.User;
 import com.listywave.user.application.dto.AllUserResponse;
+import com.listywave.user.application.dto.FeedListsDto;
 import com.listywave.user.application.dto.UserInfoResponse;
+import com.listywave.user.presentation.dto.response.AllUserListsResponse;
 import com.listywave.user.repository.UserRepository;
 import java.util.List;
 import java.util.Optional;
@@ -19,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final JwtManager jwtManager;
+    private final UserUtil userUtil;
     private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
@@ -35,6 +41,35 @@ public class UserService {
             return UserInfoResponse.of(foundUser, false, true);
         }
         return UserInfoResponse.of(foundUser, false, false);
+    }
+
+    @Transactional(readOnly = true)
+    public AllUserListsResponse getAllUserLists(
+            Long userId,
+            String type,
+            CategoryType category,
+            Long cursorId,
+            int size
+    ) {
+        User user = userUtil.getUserByUserid(userId);
+
+        List<Lists> feedList = userRepository.findFeedLists(userId, type, category, cursorId, size);
+
+        boolean hasNext = false;
+        cursorId = null;
+
+        if(feedList.size() == size + 1){
+            feedList.remove(size);
+            hasNext = true;
+            cursorId = feedList.get(feedList.size() - 1).getId();
+        }
+
+        List<FeedListsDto> collect = feedList.stream()
+                .map(FeedListsDto::of)
+                .toList();
+
+        return AllUserListsResponse.of(hasNext, cursorId, collect);
+
     }
 
     private static boolean isSignedIn(String accessToken) {

--- a/src/main/java/com/listywave/user/presentation/UserController.java
+++ b/src/main/java/com/listywave/user/presentation/UserController.java
@@ -1,13 +1,16 @@
 package com.listywave.user.presentation;
 
+import com.listywave.list.application.domain.CategoryType;
 import com.listywave.user.application.dto.AllUserResponse;
 import com.listywave.user.application.dto.UserInfoResponse;
 import com.listywave.user.application.service.UserService;
+import com.listywave.user.presentation.dto.response.AllUserListsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,5 +32,24 @@ public class UserController {
     ResponseEntity<AllUserResponse> getAllUser() {
         AllUserResponse allUserResponse = userService.getAllUser();
         return ResponseEntity.ok(allUserResponse);
+    }
+
+    @GetMapping("/users/{userId}/lists")
+    ResponseEntity<AllUserListsResponse> getAllUserLists(
+            @PathVariable(name = "userId") Long userId,
+            @RequestParam(name = "type", defaultValue = "my") String type,
+            @RequestParam(name = "category", defaultValue = "entire") CategoryType category,
+            @RequestParam(name = "cursorId", required = false) Long cursorId,
+            @RequestParam(name = "size") int size
+    ) {
+        AllUserListsResponse allUserListsResponse =
+                userService.getAllUserLists(
+                        userId,
+                        type,
+                        category,
+                        cursorId,
+                        size
+                );
+        return ResponseEntity.ok(allUserListsResponse);
     }
 }

--- a/src/main/java/com/listywave/user/presentation/UserController.java
+++ b/src/main/java/com/listywave/user/presentation/UserController.java
@@ -42,7 +42,7 @@ public class UserController {
             @RequestParam(name = "cursorId", required = false) Long cursorId,
             @RequestParam(name = "size") int size
     ) {
-        AllUserListsResponse allUserListsResponse = userService.getAllUserLists(userId, type, category, cursorId, size);
+        AllUserListsResponse allUserListsResponse = userService.getAllListOfUser(userId, type, category, cursorId, size);
         return ResponseEntity.ok(allUserListsResponse);
     }
 }

--- a/src/main/java/com/listywave/user/presentation/UserController.java
+++ b/src/main/java/com/listywave/user/presentation/UserController.java
@@ -42,14 +42,7 @@ public class UserController {
             @RequestParam(name = "cursorId", required = false) Long cursorId,
             @RequestParam(name = "size") int size
     ) {
-        AllUserListsResponse allUserListsResponse =
-                userService.getAllUserLists(
-                        userId,
-                        type,
-                        category,
-                        cursorId,
-                        size
-                );
+        AllUserListsResponse allUserListsResponse = userService.getAllUserLists(userId, type, category, cursorId, size);
         return ResponseEntity.ok(allUserListsResponse);
     }
 }

--- a/src/main/java/com/listywave/user/presentation/dto/response/AllUserListsResponse.java
+++ b/src/main/java/com/listywave/user/presentation/dto/response/AllUserListsResponse.java
@@ -1,0 +1,19 @@
+package com.listywave.user.presentation.dto.response;
+
+import com.listywave.user.application.dto.FeedListsDto;
+import java.util.List;
+import lombok.Builder;
+
+public record AllUserListsResponse(
+    Long cursorId,
+    Boolean hasNext,
+    List<FeedListsDto> feedLists
+) {
+    public static AllUserListsResponse of(boolean hasNext, Long cursorId, List<FeedListsDto> lists){
+        return new AllUserListsResponse(
+                cursorId,
+                hasNext,
+                lists
+        );
+    }
+}

--- a/src/main/java/com/listywave/user/presentation/dto/response/AllUserListsResponse.java
+++ b/src/main/java/com/listywave/user/presentation/dto/response/AllUserListsResponse.java
@@ -1,19 +1,25 @@
 package com.listywave.user.presentation.dto.response;
 
-import com.listywave.user.application.dto.FeedListsDto;
+import com.listywave.list.application.domain.Lists;
+import com.listywave.user.application.dto.FeedListsResponse;
 import java.util.List;
-import lombok.Builder;
 
 public record AllUserListsResponse(
-    Long cursorId,
-    Boolean hasNext,
-    List<FeedListsDto> feedLists
+        Long cursorId,
+        Boolean hasNext,
+        List<FeedListsResponse> feedLists
 ) {
-    public static AllUserListsResponse of(boolean hasNext, Long cursorId, List<FeedListsDto> lists){
+    public static AllUserListsResponse of(boolean hasNext, Long cursorId, List<Lists> feedLists) {
         return new AllUserListsResponse(
                 cursorId,
                 hasNext,
-                lists
+                toList(feedLists)
         );
+    }
+
+    public static List<FeedListsResponse> toList(List<Lists> feedLists) {
+        return feedLists.stream()
+                .map(FeedListsResponse::of)
+                .toList();
     }
 }

--- a/src/main/java/com/listywave/user/repository/UserRepository.java
+++ b/src/main/java/com/listywave/user/repository/UserRepository.java
@@ -1,10 +1,11 @@
 package com.listywave.user.repository;
 
 import com.listywave.user.application.domain.User;
+import com.listywave.user.repository.custom.UserRepositoryCustom;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 
     Optional<User> findByOauthId(Long oauthId);
 }

--- a/src/main/java/com/listywave/user/repository/custom/UserRepositoryCustom.java
+++ b/src/main/java/com/listywave/user/repository/custom/UserRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.listywave.user.repository.custom;
+
+import com.listywave.list.application.domain.CategoryType;
+import com.listywave.list.application.domain.Lists;
+import java.util.List;
+
+public interface UserRepositoryCustom {
+
+    List<Lists> findFeedLists(Long userId, String type, CategoryType category, Long cursorId, int size);
+}

--- a/src/main/java/com/listywave/user/repository/custom/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/listywave/user/repository/custom/impl/UserRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.listywave.user.repository.custom.impl;
+
+import static com.listywave.list.application.domain.QItem.*;
+import static com.listywave.list.application.domain.QLists.*;
+
+import com.listywave.list.application.domain.CategoryType;
+import com.listywave.list.application.domain.Lists;
+import com.listywave.user.repository.custom.UserRepositoryCustom;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+    @Override
+    public List<Lists> findFeedLists(Long userId, String type, CategoryType category, Long cursorId, int size) {
+        List<Lists> fetch = queryFactory
+                .select(lists)
+                .from(lists)
+                .leftJoin(lists.items, item)
+                .where(
+                        userIdEq(userId),
+                        typeEq(type),
+                        categoryEq(category),
+                        listIdGt(cursorId)
+                )
+                .distinct()
+                .limit(size + 1)
+                .orderBy(lists.updatedDate.desc())
+                .fetch();
+        return fetch;
+    }
+
+    private BooleanExpression listIdGt(Long cursorId) {
+        return cursorId == null ? null : lists.id.lt(cursorId);
+    }
+
+    private BooleanExpression categoryEq(CategoryType categoryCode) {
+
+        return "0".equals(categoryCode.getCodeValue()) ? null : lists.category.eq(categoryCode);
+    }
+
+    private BooleanExpression typeEq(String type) {
+        if(type.equals("my")){
+            return lists.hasCollaboration.eq(false);
+        }
+        return lists.hasCollaboration.eq(true);
+    }
+
+    private BooleanExpression userIdEq(Long userId) {
+        return userId == null ? null : lists.user.id.eq(userId);
+    }
+}

--- a/src/main/java/com/listywave/user/repository/custom/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/listywave/user/repository/custom/impl/UserRepositoryImpl.java
@@ -1,12 +1,11 @@
 package com.listywave.user.repository.custom.impl;
 
-import static com.listywave.list.application.domain.QItem.*;
-import static com.listywave.list.application.domain.QLists.*;
+import static com.listywave.list.application.domain.QItem.item;
+import static com.listywave.list.application.domain.QLists.lists;
 
 import com.listywave.list.application.domain.CategoryType;
 import com.listywave.list.application.domain.Lists;
 import com.listywave.user.repository.custom.UserRepositoryCustom;
-import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -14,7 +13,9 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class UserRepositoryImpl implements UserRepositoryCustom {
+
     private final JPAQueryFactory queryFactory;
+
     @Override
     public List<Lists> findFeedLists(Long userId, String type, CategoryType category, Long cursorId, int size) {
         List<Lists> fetch = queryFactory
@@ -39,12 +40,14 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
     }
 
     private BooleanExpression categoryEq(CategoryType categoryCode) {
-
-        return "0".equals(categoryCode.getCodeValue()) ? null : lists.category.eq(categoryCode);
+        if ("0".equals(categoryCode.getCodeValue())) {
+            return null;
+        }
+        return lists.category.eq(categoryCode);
     }
 
     private BooleanExpression typeEq(String type) {
-        if(type.equals("my")){
+        if (type.equals("my")) {
             return lists.hasCollaboration.eq(false);
         }
         return lists.hasCollaboration.eq(true);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=MySQL
+    url: jdbc:h2:tcp://localhost/~/listywave;MODE=MySQL
     username: sa
     driver-class-name: org.h2.Driver
   jpa:
@@ -11,6 +11,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         highlight_sql: true
+        default_batch_fetch_size: 100
       show-sql: true
     defer-datasource-initialization: true
   h2:
@@ -28,6 +29,8 @@ logging:
     org.springframework.orm.jpa: DEBUG
     org.springframework.orm.transaction: DEBUG
     org.apache.coyote.http11: debug
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace # 쿼리 파라미터 로그 남기기
 
 cloud:
   aws:


### PR DESCRIPTION
# Description
### 전체 리스트 API
 - Query DSL을 이용하여 cursorId를 이용한 페이지네이션을 구현
 - 필터가 되는 파라미터 : type, size, category, userId, cursorId
 - List와 Item은 서로 1 : N 관계 즉 컬렉션 조인이 필요한 상황이였어서 해당 쿼리를 fetchJoin()으로 가져올 시 hibernate가 memory에 fullscan하여 모두 가져온 뒤 해당 영역에서 limit 처리 하는 위험한 상황이 발생할 수 있음 ( Out of Memory )
 
 그래서 이는 application.yml에서 `default_batch_fetch_size: 100` 해당 옵션을 통해 프록시에서 where in 쿼리로 정한 사이즈만큼 가져올 수 있도록 최적화 진행 -> 해당 방식을 사용하지 않으면 1 : N 컬렉션 페이지네이션은 힘듬..

### Enum Category 변환
- EnumMappingConfig를 사용하여 category 파라미터로 들어오는 쿼리가 대소문자 관계없이 Enum에 매핑되기전  대문자로 처리되도록 구현 

💡 문제
- 해당 config는 쿼리파라미터에 대해서만 처리해줌 RequestBody를 통해 들어오는 부분은 처리가 안됨

👉🏼 해결
- @JsonCreator를 이용하여 CategoryType 클래스에서 별도 메서드로 처리

# Reference
 https://wangtak.tistory.com/30
https://www.baeldung.com/spring-boot-enum-mapping
https://blog.naver.com/PostView.naver?blogId=simpolor&logNo=221598980908

# Relation Issues
- close (#27)
