### PR TITLE
feat: 팔로우 해제 API 구현

### DIFF
--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -84,4 +84,13 @@ public class UserService {
                 .toList();
         return FollowingsResponse.of(followingUsers);
     }
+
+    public void unfollow(Long followingUserId, String accessToken) {
+        User followingUser = userRepository.getById(followingUserId);
+
+        Long loginUserId = jwtManager.read(accessToken);
+        User followerUser = userRepository.getById(loginUserId);
+
+        followRepository.deleteByFollowingUserAndFollowerUser(followingUser, followerUser);
+    }
 }

--- a/src/main/java/com/listywave/user/presentation/UserController.java
+++ b/src/main/java/com/listywave/user/presentation/UserController.java
@@ -58,10 +58,10 @@ public class UserController {
 
     @DeleteMapping("/follow/{userId}")
     ResponseEntity<Void> unfollow(
-            @PathVariable(value = "userId") Long targetUserId,
-            @RequestHeader(value = AUTHORIZATION) String accessToken
+            @PathVariable(value = "userId") Long followingUserId,
+            @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken
     ) {
-        userService.unfollow(targetUserId, accessToken);
+        userService.unfollow(followingUserId, accessToken);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/listywave/user/presentation/UserController.java
+++ b/src/main/java/com/listywave/user/presentation/UserController.java
@@ -10,6 +10,7 @@ import com.listywave.user.application.dto.UserInfoResponse;
 import com.listywave.user.application.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -53,5 +54,14 @@ public class UserController {
     ResponseEntity<FollowingsResponse> getFollowings(@RequestHeader(value = AUTHORIZATION) String accessToken) {
         FollowingsResponse response = userService.getFollowings(accessToken);
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/follow/{userId}")
+    ResponseEntity<Void> unfollow(
+            @PathVariable(value = "userId") Long targetUserId,
+            @RequestHeader(value = AUTHORIZATION) String accessToken
+    ) {
+        userService.unfollow(targetUserId, accessToken);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/listywave/user/repository/follow/FollowRepository.java
+++ b/src/main/java/com/listywave/user/repository/follow/FollowRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     List<Follow> getAllByFollowerUser(User user);
+
+    void deleteByFollowingUserAndFollowerUser(User following, User follower);
 }


### PR DESCRIPTION
# Description
- 팔로우 해제 API를 구현했습니다.
- Path에 followingUserId를 받고, AccessToken으로 follwerUser를 식별합니다.
  그리고 Follow 테이블에서 위 두 User를 이용해 데이터를 삭제하는 방식으로 구현했습니다.

# Relation Issues
- close #67 
