### PR TITLE
feat: 최신 리스트 10개 조회 API 구현

### DIFF
--- a/src/main/java/com/listywave/list/application/dto/response/ListRecentResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/ListRecentResponse.java
@@ -32,6 +32,12 @@ record ListResponse(
         List<ItemsResponse> items
 ) {
 
+    public static List<ListResponse> toList(List<Lists> lists) {
+        return lists.stream()
+                .map(ListResponse::of)
+                .toList();
+    }
+
     public static ListResponse of(Lists lists) {
         return ListResponse.builder()
                 .id(lists.getId())
@@ -46,12 +52,6 @@ record ListResponse(
                 .items(ItemsResponse.toList(lists.getItems()))
                 .build();
     }
-
-    public static List<ListResponse> toList(List<Lists> lists) {
-        return lists.stream()
-                .map(ListResponse::of)
-                .toList();
-    }
 }
 
 @Builder
@@ -60,17 +60,17 @@ record LabelsResponse(
         String name
 ) {
 
+    public static List<LabelsResponse> toList(List<Label> labels) {
+        return labels.stream()
+                .map(LabelsResponse::of)
+                .toList();
+    }
+
     public static LabelsResponse of(Label label) {
         return LabelsResponse.builder()
                 .id(label.getId())
                 .name(label.getLabelName())
                 .build();
-    }
-
-    public static List<LabelsResponse> toList(List<Label> labels) {
-        return labels.stream()
-                .map(LabelsResponse::of)
-                .toList();
     }
 }
 
@@ -82,6 +82,14 @@ record ItemsResponse(
         String imageUrl
 ) {
 
+    public static List<ItemsResponse> toList(List<Item> items) {
+        return items.stream()
+                .sorted(Comparator.comparing(Item::getRanking))
+                .map(ItemsResponse::of)
+                .limit(3)
+                .toList();
+    }
+
     public static ItemsResponse of(Item item) {
         return ItemsResponse.builder()
                 .id(item.getId())
@@ -89,13 +97,5 @@ record ItemsResponse(
                 .title(item.getTitle())
                 .imageUrl(item.getImageUrl())
                 .build();
-    }
-
-    public static List<ItemsResponse> toList(List<Item> items) {
-        return items.stream()
-                .sorted(Comparator.comparing(Item::getRanking))
-                .map(ItemsResponse::of)
-                .limit(3)
-                .toList();
     }
 }

--- a/src/main/java/com/listywave/list/application/dto/response/ListRecentResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/ListRecentResponse.java
@@ -1,0 +1,101 @@
+package com.listywave.list.application.dto.response;
+
+import com.listywave.list.application.domain.Item;
+import com.listywave.list.application.domain.Label;
+import com.listywave.list.application.domain.Lists;
+import java.util.Comparator;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ListRecentResponse(
+        List<ListResponse> lists
+) {
+    public static ListRecentResponse of(List<Lists> lists) {
+        return ListRecentResponse.builder()
+                .lists(ListResponse.toList(lists))
+                .build();
+    }
+}
+
+@Builder
+record ListResponse(
+        Long id,
+        String category,
+        String backgroundColor,
+        Long ownerId,
+        String ownerNickname,
+        String ownerProfileImage,
+        List<LabelsResponse> labels,
+        String title,
+        String description,
+        List<ItemsResponse> items
+) {
+
+    public static ListResponse of(Lists lists) {
+        return ListResponse.builder()
+                .id(lists.getId())
+                .category(lists.getCategory().getKorNameValue())
+                .backgroundColor(lists.getBackgroundColor())
+                .ownerId(lists.getUser().getId())
+                .ownerNickname(lists.getUser().getNickname())
+                .ownerProfileImage(lists.getUser().getProfileImageUrl())
+                .labels(LabelsResponse.toList(lists.getLabels()))
+                .title(lists.getTitle())
+                .description(lists.getDescription())
+                .items(ItemsResponse.toList(lists.getItems()))
+                .build();
+    }
+
+    public static List<ListResponse> toList(List<Lists> lists) {
+        return lists.stream()
+                .map(ListResponse::of)
+                .toList();
+    }
+}
+
+@Builder
+record LabelsResponse(
+        Long id,
+        String name
+) {
+
+    public static LabelsResponse of(Label label) {
+        return LabelsResponse.builder()
+                .id(label.getId())
+                .name(label.getLabelName())
+                .build();
+    }
+
+    public static List<LabelsResponse> toList(List<Label> labels) {
+        return labels.stream()
+                .map(LabelsResponse::of)
+                .toList();
+    }
+}
+
+@Builder
+record ItemsResponse(
+        Long id,
+        int ranking,
+        String title,
+        String imageUrl
+) {
+
+    public static ItemsResponse of(Item item) {
+        return ItemsResponse.builder()
+                .id(item.getId())
+                .ranking(item.getRanking())
+                .title(item.getTitle())
+                .imageUrl(item.getImageUrl())
+                .build();
+    }
+
+    public static List<ItemsResponse> toList(List<Item> items) {
+        return items.stream()
+                .sorted(Comparator.comparing(Item::getRanking))
+                .map(ItemsResponse::of)
+                .limit(3)
+                .toList();
+    }
+}

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -140,11 +140,7 @@ public class ListService {
 
     @Transactional(readOnly = true)
     public ListRecentResponse getRecentLists(String accessToken) {
-
         if (isSignedIn(accessToken)) {
-            List<Lists> recentLists = listRepository.getRecentLists();
-            return ListRecentResponse.of(recentLists);
-        } else {
             Long loginUserId = jwtManager.read(accessToken);
             User user = userRepository.getById(loginUserId);
             List<Follow> follows = followRepository.getAllByFollowerUser(user);
@@ -155,9 +151,12 @@ public class ListService {
             List<Lists> recentListsByFollowing = listRepository.getRecentListsByFollowing(followingUsers);
             return ListRecentResponse.of(recentListsByFollowing);
         }
+        List<Lists> recentLists = listRepository.getRecentLists();
+        return ListRecentResponse.of(recentLists);
+
     }
 
     private boolean isSignedIn(String accessToken) {
-        return accessToken.isBlank();
+        return !accessToken.isBlank();
     }
 }

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -1,5 +1,6 @@
 package com.listywave.list.application.service;
 
+import com.listywave.auth.application.domain.JwtManager;
 import com.listywave.collaborator.domain.Collaborator;
 import com.listywave.collaborator.domain.repository.CollaboratorRepository;
 import com.listywave.common.exception.CustomException;
@@ -10,10 +11,13 @@ import com.listywave.list.application.domain.Lists;
 import com.listywave.list.application.dto.ListCreateCommand;
 import com.listywave.list.application.dto.response.ListCreateResponse;
 import com.listywave.list.application.dto.response.ListDetailResponse;
+import com.listywave.list.application.dto.response.ListRecentResponse;
 import com.listywave.list.application.dto.response.ListTrandingResponse;
 import com.listywave.list.presentation.dto.request.ItemCreateRequest;
 import com.listywave.list.repository.list.ListRepository;
+import com.listywave.user.application.domain.Follow;
 import com.listywave.user.application.domain.User;
+import com.listywave.user.repository.follow.FollowRepository;
 import com.listywave.user.repository.user.UserRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -27,9 +31,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class ListService {
 
     private final UserUtil userUtil;
+    private final JwtManager jwtManager;
     private final ListRepository listRepository;
     private final UserRepository userRepository;
     private final CollaboratorRepository collaboratorRepository;
+    private final FollowRepository followRepository;
 
     public ListCreateResponse listCreate(
             ListCreateCommand listCreateCommand,
@@ -132,4 +138,26 @@ public class ListService {
                 .orElse("");
     }
 
+    @Transactional(readOnly = true)
+    public ListRecentResponse getRecentLists(String accessToken) {
+
+        if (isSignedIn(accessToken)) {
+            List<Lists> recentLists = listRepository.getRecentLists();
+            return ListRecentResponse.of(recentLists);
+        } else {
+            Long loginUserId = jwtManager.read(accessToken);
+            User user = userRepository.getById(loginUserId);
+            List<Follow> follows = followRepository.getAllByFollowerUser(user);
+
+            List<User> followingUsers = follows.stream()
+                    .map(Follow::getFollowingUser)
+                    .toList();
+            List<Lists> recentListsByFollowing = listRepository.getRecentListsByFollowing(followingUsers);
+            return ListRecentResponse.of(recentListsByFollowing);
+        }
+    }
+
+    private boolean isSignedIn(String accessToken) {
+        return accessToken.isBlank();
+    }
 }

--- a/src/main/java/com/listywave/list/presentation/controller/ListController.java
+++ b/src/main/java/com/listywave/list/presentation/controller/ListController.java
@@ -3,6 +3,7 @@ package com.listywave.list.presentation.controller;
 import com.listywave.list.application.dto.ListCreateCommand;
 import com.listywave.list.application.dto.response.ListCreateResponse;
 import com.listywave.list.application.dto.response.ListDetailResponse;
+import com.listywave.list.application.dto.response.ListRecentResponse;
 import com.listywave.list.application.dto.response.ListTrandingResponse;
 import com.listywave.list.application.service.ListService;
 import com.listywave.list.presentation.dto.request.ListCreateRequest;
@@ -50,5 +51,13 @@ public class ListController {
     ResponseEntity<List<ListTrandingResponse>> getTrandingList() {
         List<ListTrandingResponse> trandingList = listService.getTrandingList();
         return ResponseEntity.ok().body(trandingList);
+    }
+
+    @GetMapping()
+    ResponseEntity<ListRecentResponse> getRecentLists(
+            @RequestHeader(value = "Authorization", defaultValue = "") String accessToken
+    ) {
+        ListRecentResponse recentLists = listService.getRecentLists(accessToken);
+        return ResponseEntity.ok(recentLists);
     }
 }

--- a/src/main/java/com/listywave/list/repository/list/custom/CustomListRepository.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/CustomListRepository.java
@@ -1,9 +1,14 @@
 package com.listywave.list.repository.list.custom;
 
 import com.listywave.list.application.domain.Lists;
+import com.listywave.user.application.domain.User;
 import java.util.List;
 
 public interface CustomListRepository {
 
     List<Lists> findTrandingLists();
+
+    List<Lists> getRecentLists();
+
+    List<Lists> getRecentListsByFollowing(List<User> followingUsers);
 }

--- a/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
@@ -5,7 +5,6 @@ import static com.listywave.list.application.domain.QLabel.label;
 import static com.listywave.list.application.domain.QLists.lists;
 import static com.listywave.user.application.domain.QUser.user;
 
-import com.listywave.common.BaseEntity;
 import com.listywave.list.application.domain.Lists;
 import com.listywave.list.repository.list.custom.CustomListRepository;
 import com.listywave.user.application.domain.User;
@@ -21,19 +20,18 @@ public class CustomListRepositoryImpl implements CustomListRepository {
 
     @Override
     public List<Lists> findTrandingLists() {
-        List<Lists> fetch = queryFactory
+        return queryFactory
                 .selectFrom(lists)
                 .leftJoin(lists.items, item)
                 .distinct()
                 .limit(10)
                 .orderBy(lists.collectCount.desc(), lists.viewCount.desc())
                 .fetch();
-        return fetch;
     }
 
     @Override
     public List<Lists> getRecentLists() {
-        List<Lists> fetch = queryFactory
+        return queryFactory
                 .selectFrom(lists)
                 .join(lists.user, user).fetchJoin()
                 .leftJoin(lists.labels, label)
@@ -42,25 +40,23 @@ public class CustomListRepositoryImpl implements CustomListRepository {
                 .limit(10)
                 .orderBy(lists.updatedDate.desc())
                 .fetch();
-        return fetch;
     }
 
     @Override
     public List<Lists> getRecentListsByFollowing(List<User> followingUsers) {
-        List<Lists> fetch = queryFactory
+        return queryFactory
                 .selectFrom(lists)
                 .join(lists.user, user).fetchJoin()
                 .leftJoin(lists.labels, label)
                 .leftJoin(lists.items, item)
                 .where(lists.user.id.in(
                         followingUsers.stream()
-                                .map(BaseEntity::getId)
+                                .map(User::getId)
                                 .collect(Collectors.toList())
                 ))
                 .distinct()
                 .limit(10)
                 .orderBy(lists.updatedDate.desc())
                 .fetch();
-        return fetch;
     }
 }

--- a/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
@@ -1,14 +1,17 @@
 package com.listywave.list.repository.list.custom.impl;
 
 import static com.listywave.list.application.domain.QItem.item;
+import static com.listywave.list.application.domain.QLabel.label;
 import static com.listywave.list.application.domain.QLists.lists;
+import static com.listywave.user.application.domain.QUser.user;
 
-import com.listywave.list.application.domain.Item;
+import com.listywave.common.BaseEntity;
 import com.listywave.list.application.domain.Lists;
 import com.listywave.list.repository.list.custom.CustomListRepository;
+import com.listywave.user.application.domain.User;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -25,11 +28,39 @@ public class CustomListRepositoryImpl implements CustomListRepository {
                 .limit(10)
                 .orderBy(lists.collectCount.desc(), lists.viewCount.desc())
                 .fetch();
+        return fetch;
+    }
 
-        fetch.forEach(
-                list -> list.getItems()
-                        .sort(Comparator.comparing(Item::getRanking))
-        );
+    @Override
+    public List<Lists> getRecentLists() {
+        List<Lists> fetch = queryFactory
+                .selectFrom(lists)
+                .join(lists.user, user).fetchJoin()
+                .leftJoin(lists.labels, label)
+                .leftJoin(lists.items, item)
+                .distinct()
+                .limit(10)
+                .orderBy(lists.updatedDate.desc())
+                .fetch();
+        return fetch;
+    }
+
+    @Override
+    public List<Lists> getRecentListsByFollowing(List<User> followingUsers) {
+        List<Lists> fetch = queryFactory
+                .selectFrom(lists)
+                .join(lists.user, user).fetchJoin()
+                .leftJoin(lists.labels, label)
+                .leftJoin(lists.items, item)
+                .where(lists.user.id.in(
+                        followingUsers.stream()
+                                .map(BaseEntity::getId)
+                                .collect(Collectors.toList())
+                ))
+                .distinct()
+                .limit(10)
+                .orderBy(lists.updatedDate.desc())
+                .fetch();
         return fetch;
     }
 }


### PR DESCRIPTION
# Description
- 비회원 ⇒ 전체 리스트 중 최신 10개 가져오도록 구현 (item은 1~3위까지 만 가져오도록)
- 회원 ⇒ 내가 팔로우 한 유저의 리스트 중 최신 10개 가져오도록 구현 (item은 1~3위까지 만 가져오도록)
# Reference

# Relation Issues
- close #73 
