### PR TITLE
feat: 리스트 삭제 API 구현

### DIFF
--- a/src/main/java/com/listywave/ListywaveApplication.java
+++ b/src/main/java/com/listywave/ListywaveApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication
 @ConfigurationPropertiesScan(basePackages = {"com.listywave"})

--- a/src/main/java/com/listywave/collaborator/domain/repository/CollaboratorRepository.java
+++ b/src/main/java/com/listywave/collaborator/domain/repository/CollaboratorRepository.java
@@ -1,10 +1,13 @@
 package com.listywave.collaborator.domain.repository;
 
 import com.listywave.collaborator.domain.Collaborator;
+import com.listywave.list.application.domain.Lists;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CollaboratorRepository extends JpaRepository<Collaborator, Long> {
-    
+
     List<Collaborator> findAllByListId(Long listId);
+
+    void deleteAllByList(Lists lists);
 }

--- a/src/main/java/com/listywave/common/exception/ErrorCode.java
+++ b/src/main/java/com/listywave/common/exception/ErrorCode.java
@@ -26,7 +26,11 @@ public enum ErrorCode {
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 AccessToken 입니다. 다시 로그인해주세요."),
 
     // list
-    INVALID_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 존재하지 않습니다.");
+    INVALID_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 존재하지 않습니다."),
+
+    // S3
+    S3_DELETE_OBJECTS_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류, 관리자에게 문의하세요"),
+    ;
 
     private final HttpStatus status;
     private final String detail;

--- a/src/main/java/com/listywave/image/application/service/ImageService.java
+++ b/src/main/java/com/listywave/image/application/service/ImageService.java
@@ -205,19 +205,16 @@ public class ImageService {
 
     @Async
     public void deleteAllOfListImages(Long listId) {
-        String path = "/" + getCurrentProfile() + "/lists_item/" + listId + "/";
-
-        ListObjectsV2Result listObjects;
-        do {
-            listObjects = amazonS3.listObjectsV2(bucket, path);
-            for (S3ObjectSummary object : listObjects.getObjectSummaries()) {
-                amazonS3.deleteObject(new DeleteObjectRequest(bucket, object.getKey()));
-            }
-            listObjects.setContinuationToken(listObjects.getNextContinuationToken());
-        } while (listObjects.isTruncated());
-
+        String path = getCurrentProfile() + "/lists_item/" + listId + "/";
         try {
-            amazonS3.deleteObject(bucket, path);
+            ListObjectsV2Result listObjects;
+            do {
+                listObjects = amazonS3.listObjectsV2(bucket, path);
+                for (S3ObjectSummary object : listObjects.getObjectSummaries()) {
+                    amazonS3.deleteObject(new DeleteObjectRequest(bucket, object.getKey()));
+                }
+                listObjects.setContinuationToken(listObjects.getNextContinuationToken());
+            } while (listObjects.isTruncated());
         } catch (AmazonServiceException e) {
             throw new CustomException(S3_DELETE_OBJECTS_EXCEPTION);
         }

--- a/src/main/java/com/listywave/list/presentation/controller/ListController.java
+++ b/src/main/java/com/listywave/list/presentation/controller/ListController.java
@@ -11,6 +11,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -51,6 +52,12 @@ public class ListController {
     ResponseEntity<List<ListTrandingResponse>> getTrandingList() {
         List<ListTrandingResponse> trandingList = listService.getTrandingList();
         return ResponseEntity.ok().body(trandingList);
+    }
+
+    @DeleteMapping("/{listId}")
+    ResponseEntity<Void> deleteList(@PathVariable(value = "listId") Long listId) {
+        listService.deleteList(listId);
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping()

--- a/src/main/java/com/listywave/list/repository/CommentRepository.java
+++ b/src/main/java/com/listywave/list/repository/CommentRepository.java
@@ -5,6 +5,7 @@ import static com.listywave.common.exception.ErrorCode.NOT_FOUND;
 import com.listywave.common.exception.CustomException;
 import com.listywave.list.application.domain.Comment;
 import com.listywave.list.application.domain.Lists;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long>, CustomCommentRepository {
@@ -14,4 +15,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, CustomC
     }
 
     Long countByList(Lists list);
+
+    List<Comment> findAllByList(Lists list);
 }

--- a/src/main/java/com/listywave/list/repository/ReplyRepository.java
+++ b/src/main/java/com/listywave/list/repository/ReplyRepository.java
@@ -10,4 +10,6 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
     boolean existsByComment(Comment comment);
 
     List<Reply> getAllByComment(Comment comment);
+
+    void deleteAllByCommentIn(List<Comment> comments);
 }


### PR DESCRIPTION
# Description
- 리스트 삭제 API를 구현했습니다.
  - 해당 리스트에 속한 아이템의 사진을 지우는 로직은 `ImageService`에 만들어두었습니다.
    GPT랑 짰는데 제대로 동작할지는 모르겠네요...
    S3 전문가 정수님이 한번 봐주시면 감사하겠습니다 😅
  - Item, Labels는 cascade 옵션으로 제거됩니다.
  - Collaborator, Comment, Reply는 따로 삭제 처리 했습니다.

# Relation Issues
- close #62 
