### PR TITLE
feat: 리스트의 댓글/답글 조회 시, totalCount에 Reply의 수가 빠진 것 수정

### DIFF
--- a/src/main/java/com/listywave/list/repository/CommentRepository.java
+++ b/src/main/java/com/listywave/list/repository/CommentRepository.java
@@ -14,7 +14,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, CustomC
         return findById(id).orElseThrow(() -> new CustomException(NOT_FOUND));
     }
 
-    Long countByList(Lists list);
-
     List<Comment> findAllByList(Lists list);
 }

--- a/src/main/java/com/listywave/list/repository/CustomCommentRepository.java
+++ b/src/main/java/com/listywave/list/repository/CustomCommentRepository.java
@@ -1,9 +1,10 @@
 package com.listywave.list.repository;
 
 import com.listywave.list.application.domain.Comment;
+import com.listywave.list.application.domain.Lists;
 import java.util.List;
 
 public interface CustomCommentRepository {
 
-    List<Comment> getComments(Long listId, int size, Long cursorId);
+    List<Comment> getComments(Lists list, int size, Long cursorId);
 }

--- a/src/main/java/com/listywave/list/repository/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/listywave/list/repository/CustomCommentRepositoryImpl.java
@@ -4,6 +4,7 @@ import static com.listywave.list.application.domain.QComment.comment;
 import static com.listywave.list.application.domain.QLists.lists;
 
 import com.listywave.list.application.domain.Comment;
+import com.listywave.list.application.domain.Lists;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,14 +15,14 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Comment> getComments(Long listId, int size, Long cursorId) {
+    public List<Comment> getComments(Lists list, int size, Long cursorId) {
         return queryFactory.selectFrom(comment)
                 .join(comment.list, lists)
                 .where(
-                        comment.list.id.eq(listId),
-                        comment.id.gt(cursorId)
+                        comment.list.eq(list),
+                        comment.id.lt(cursorId)
                 )
-                .orderBy(comment.id.asc())
+                .orderBy(comment.id.desc())
                 .limit(size + 1)
                 .fetch();
     }


### PR DESCRIPTION
# Description
- 리스트의 댓글/답글 조회 시, `totalCount` 필드에 답글의 수가 빠진 내용 수정했습니다.
- 동시에 리팩터링도 함께 진행했습니다.

# Relation Issues
- close #87 
