### PR TITLE
feat: 사용자 배경이미지, 프로필이미지 Presigned url 관련 수정 API 구현

### DIFF
--- a/src/main/java/com/listywave/image/application/dto/response/ItemPresignedUrlResponse.java
+++ b/src/main/java/com/listywave/image/application/dto/response/ItemPresignedUrlResponse.java
@@ -1,0 +1,13 @@
+package com.listywave.image.application.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record ItemPresignedUrlResponse(int rank, String presignedUrl) {
+    public static ItemPresignedUrlResponse of(int rank, String presignedUrl) {
+        return ItemPresignedUrlResponse.builder()
+                .rank(rank)
+                .presignedUrl(presignedUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/listywave/image/application/dto/response/UserPresignedUrlResponse.java
+++ b/src/main/java/com/listywave/image/application/dto/response/UserPresignedUrlResponse.java
@@ -1,0 +1,15 @@
+package com.listywave.image.application.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record UserPresignedUrlResponse(Long ownerId, String profilePresignedUrl, String backgroundPresignedUrl) {
+
+    public static UserPresignedUrlResponse of(Long ownerId, String profilePresignedUrl, String backgroundPresignedUrl) {
+        return UserPresignedUrlResponse.builder()
+                .ownerId(ownerId)
+                .profilePresignedUrl(profilePresignedUrl)
+                .backgroundPresignedUrl(backgroundPresignedUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/listywave/image/application/service/ImageService.java
+++ b/src/main/java/com/listywave/image/application/service/ImageService.java
@@ -11,6 +11,7 @@ import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.listywave.auth.application.domain.JwtManager;
 import com.listywave.common.exception.CustomException;
 import com.listywave.common.exception.ErrorCode;
 import com.listywave.common.util.UserUtil;
@@ -50,6 +51,7 @@ public class ImageService {
     private final Environment environment;
     private final AmazonS3 amazonS3;
     private final UserUtil userUtil;
+    private final JwtManager jwtManager;
     private final ItemRepository itemRepository;
     private final ListRepository listRepository;
     private final UserRepository userRepository;
@@ -109,6 +111,7 @@ public class ImageService {
             ImageFileExtension backgroundExtension,
             String accessToken
     ) {
+        jwtManager.read(accessToken);
         User user = userRepository.getById(ownerId);
 
         if (isExistProfileExtension(profileExtension, backgroundExtension)) {

--- a/src/main/java/com/listywave/image/application/service/ImageService.java
+++ b/src/main/java/com/listywave/image/application/service/ImageService.java
@@ -17,12 +17,14 @@ import com.listywave.common.util.UserUtil;
 import com.listywave.image.application.domain.ImageFileExtension;
 import com.listywave.image.application.domain.ImageType;
 import com.listywave.image.application.dto.ExtensionRanks;
-import com.listywave.image.presentation.dto.response.PresignedUrlResponse;
+import com.listywave.image.application.dto.response.ItemPresignedUrlResponse;
+import com.listywave.image.application.dto.response.UserPresignedUrlResponse;
 import com.listywave.list.application.domain.Item;
 import com.listywave.list.application.domain.Lists;
 import com.listywave.list.repository.ItemRepository;
 import com.listywave.list.repository.list.ListRepository;
 import com.listywave.user.application.domain.User;
+import com.listywave.user.repository.user.UserRepository;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -50,8 +52,9 @@ public class ImageService {
     private final UserUtil userUtil;
     private final ItemRepository itemRepository;
     private final ListRepository listRepository;
+    private final UserRepository userRepository;
 
-    public List<PresignedUrlResponse> createListsPresignedUrl(Long ownerId, Long listId, List<ExtensionRanks> extensionRanks) {
+    public List<ItemPresignedUrlResponse> createListsPresignedUrl(Long ownerId, Long listId, List<ExtensionRanks> extensionRanks) {
 
         //TODO: 회원이 존재하는지 않하는지 검증 (security)
         final User user = userUtil.getUserByUserid(ownerId);
@@ -62,22 +65,16 @@ public class ImageService {
         return extensionRanks.stream()
                 .map((extensionRank) -> {
                             String imageKey = generatedUUID();
-                            String fileName =
-                                    createFileName(
+                            GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                                    getGeneratePresignedUrl(
                                             ImageType.LISTS_ITEM,
                                             listId,
                                             imageKey,
                                             extensionRank.extension()
                                     );
-                            GeneratePresignedUrlRequest generatePresignedUrlRequest =
-                                    createGeneratePreSignedUrlRequest(
-                                            bucket,
-                                            fileName
-                                    );
+                            updateItemImageKey(listId, extensionRank, imageKey);
 
-                            updateImageKey(listId, extensionRank, imageKey);
-
-                            return PresignedUrlResponse.of(
+                            return ItemPresignedUrlResponse.of(
                                     extensionRank.rank(),
                                     amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString());
                         }
@@ -105,6 +102,239 @@ public class ImageService {
                 }
         );
     }
+
+    public UserPresignedUrlResponse updateUserImagePresignedUrl(
+            Long ownerId,
+            ImageFileExtension profileExtension,
+            ImageFileExtension backgroundExtension,
+            String accessToken
+    ) {
+        User user = userRepository.getById(ownerId);
+
+        if (isExistProfileExtension(profileExtension, backgroundExtension)) {
+            deleteCustomUserImageFile(user.getProfileImageUrl());
+            return getUserPresignedUrlResponse(
+                    ImageType.USER_PROFILE,
+                    null,
+                    profileExtension,
+                    backgroundExtension,
+                    user,
+                    false
+            );
+        }
+
+        if (isExistBackgroundExtension(backgroundExtension, profileExtension)) {
+            deleteCustomUserImageFile(user.getBackgroundImageUrl());
+            return getUserPresignedUrlResponse(
+                    null,
+                    ImageType.USER_BACKGROUND,
+                    profileExtension,
+                    backgroundExtension,
+                    user,
+                    false
+            );
+        }
+
+        deleteCustomUserImageFile(user.getProfileImageUrl());
+        deleteCustomUserImageFile(user.getBackgroundImageUrl());
+
+        return getUserPresignedUrlResponse(
+                ImageType.USER_PROFILE,
+                ImageType.USER_BACKGROUND,
+                profileExtension,
+                backgroundExtension,
+                user,
+                true
+        );
+    }
+
+    public void uploadCompleteUserImages(
+            Long ownerId,
+            ImageFileExtension profileExtension,
+            ImageFileExtension backgroundExtension
+    ) {
+        User user = userRepository.getById(ownerId);
+
+        String profileImageUrl = "";
+        String backgroundImageUrl = "";
+        Boolean isBoth = true;
+        if (isExistProfileExtension(profileExtension, backgroundExtension)) {
+            profileImageUrl = createReadImageUrl(
+                    ImageType.USER_PROFILE,
+                    user.getId(),
+                    user.getProfileImageUrl(),
+                    profileExtension
+            );
+            user.updateUserImageUrl(profileImageUrl, backgroundImageUrl);
+            isBoth = false;
+        }
+
+        if (isExistBackgroundExtension(backgroundExtension, profileExtension)) {
+            backgroundImageUrl = createReadImageUrl(
+                    ImageType.USER_BACKGROUND,
+                    user.getId(),
+                    user.getBackgroundImageUrl(),
+                    backgroundExtension
+            );
+            user.updateUserImageUrl(profileImageUrl, backgroundImageUrl);
+            isBoth = false;
+        }
+
+        if (isBoth) {
+            profileImageUrl = createReadImageUrl(
+                    ImageType.USER_PROFILE,
+                    user.getId(),
+                    user.getProfileImageUrl(),
+                    profileExtension
+            );
+            backgroundImageUrl = createReadImageUrl(
+                    ImageType.USER_BACKGROUND,
+                    user.getId(),
+                    user.getBackgroundImageUrl(),
+                    backgroundExtension
+            );
+            user.updateUserImageUrl(profileImageUrl, backgroundImageUrl);
+        }
+    }
+
+    private void deleteCustomUserImageFile(String imageUrl) {
+        if (isCustomUserImage(imageUrl)) {
+            String fileFullPath = getFileFullName(imageUrl);
+            deleteImageFile(fileFullPath);
+        }
+    }
+
+    private void deleteImageFile(String fileFullPath) {
+        try {
+            amazonS3.deleteObject(bucket, fileFullPath);
+        } catch (AmazonServiceException e) {
+            throw new CustomException(ErrorCode.S3_DELETE_OBJECTS_EXCEPTION);
+        }
+    }
+
+    private boolean isCustomUserImage(String url) {
+        if (url.split("/").length >= 4) {
+            String type = url.split("/")[3];
+            return !type.equals("basic");
+        }
+        return false;
+    }
+
+    private String getFileFullName(String url) {
+        String[] parts = url.split("/");
+        StringBuilder extracted = new StringBuilder();
+        for (int i = 3; i < parts.length; i++) {
+            extracted.append(parts[i]);
+            if (i < parts.length - 1) {
+                extracted.append("/");
+            }
+        }
+        return extracted.toString();
+    }
+
+    private UserPresignedUrlResponse getUserPresignedUrlResponse(
+            ImageType profileImageType,
+            ImageType backgroundImageType,
+            ImageFileExtension profileExtension,
+            ImageFileExtension backgroundExtension,
+            User user,
+            Boolean isBoth
+    ) {
+        String profileImageKey = "";
+        String backgroundImageKey = "";
+
+        if (profileImageType != null && !isBoth) {
+            profileImageKey = generatedUUID();
+
+            GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                    getGeneratePresignedUrl(
+                            profileImageType,
+                            user.getId(),
+                            profileImageKey,
+                            profileExtension
+                    );
+
+            updateUserImageKey(user, profileImageKey, backgroundImageKey);
+            return UserPresignedUrlResponse.of(
+                    user.getId(),
+                    amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString(),
+                    ""
+            );
+        }
+
+        if (backgroundImageType != null && !isBoth) {
+            backgroundImageKey = generatedUUID();
+
+            GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                    getGeneratePresignedUrl(
+                            backgroundImageType,
+                            user.getId(),
+                            backgroundImageKey,
+                            backgroundExtension
+                    );
+
+            updateUserImageKey(user, profileImageKey, backgroundImageKey);
+            return UserPresignedUrlResponse.of(
+                    user.getId(),
+                    "",
+                    amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString()
+            );
+        }
+
+        profileImageKey = generatedUUID();
+        backgroundImageKey = generatedUUID();
+
+        GeneratePresignedUrlRequest generateProfilePresignedUrlRequest =
+                getGeneratePresignedUrl(
+                        profileImageType,
+                        user.getId(),
+                        profileImageKey,
+                        profileExtension
+                );
+        GeneratePresignedUrlRequest generateBackgroundPresignedUrlRequest =
+                getGeneratePresignedUrl(
+                        backgroundImageType,
+                        user.getId(),
+                        backgroundImageKey,
+                        backgroundExtension
+                );
+
+        updateUserImageKey(user, profileImageKey, backgroundImageKey);
+        return UserPresignedUrlResponse.of(
+                user.getId(),
+                amazonS3.generatePresignedUrl(generateProfilePresignedUrlRequest).toString(),
+                amazonS3.generatePresignedUrl(generateBackgroundPresignedUrlRequest).toString()
+        );
+    }
+
+    private boolean isExistProfileExtension(
+            ImageFileExtension profileExtension,
+            ImageFileExtension backgroundExtension
+    ) {
+        return backgroundExtension == null &&
+                profileExtension != null &&
+                !profileExtension.getUploadExtension().isEmpty();
+    }
+
+    private boolean isExistBackgroundExtension(
+            ImageFileExtension backgroundExtension,
+            ImageFileExtension profileExtension
+    ) {
+        return profileExtension == null &&
+                backgroundExtension != null &&
+                !backgroundExtension.getUploadExtension().isEmpty();
+    }
+
+    private GeneratePresignedUrlRequest getGeneratePresignedUrl(
+            ImageType type,
+            Long targetId,
+            String imageKey,
+            ImageFileExtension extension
+    ) {
+        String fileName = createFileName(type, targetId, imageKey, extension);
+        return createGeneratePreSignedUrlRequest(bucket, fileName);
+    }
+
 
     private String createReadImageUrl(
             ImageType imageType,
@@ -142,9 +372,13 @@ public class ImageService {
                 + imageFileExtension.getUploadExtension();
     }
 
-    private void updateImageKey(Long listId, ExtensionRanks extensionRank, String imageKey) {
+    private void updateItemImageKey(Long listId, ExtensionRanks extensionRank, String imageKey) {
         findItem(listId, extensionRank.rank())
                 .updateItemImageKey(imageKey);
+    }
+
+    private void updateUserImageKey(User user, String profileImageKey, String backgroundImageKey) {
+        user.updateUserImageUrl(profileImageKey, backgroundImageKey);
     }
 
     private Item findItem(Long listId, int rank) {

--- a/src/main/java/com/listywave/image/presentation/controller/ImageController.java
+++ b/src/main/java/com/listywave/image/presentation/controller/ImageController.java
@@ -1,13 +1,18 @@
 package com.listywave.image.presentation.controller;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import com.listywave.image.application.dto.response.ItemPresignedUrlResponse;
+import com.listywave.image.application.dto.response.UserPresignedUrlResponse;
 import com.listywave.image.application.service.ImageService;
 import com.listywave.image.presentation.dto.request.ListsImagesCreateRequest;
-import com.listywave.image.presentation.dto.response.PresignedUrlResponse;
+import com.listywave.image.presentation.dto.request.UserImageUpdateRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,7 +22,7 @@ public class ImageController {
     private final ImageService imageService;
 
     @PostMapping("/lists/upload-url")
-    public ResponseEntity<List<PresignedUrlResponse>> listItemPresignedUrlCreate(
+    ResponseEntity<List<ItemPresignedUrlResponse>> listItemPresignedUrlCreate(
             @RequestBody ListsImagesCreateRequest request
     ) {
         return ResponseEntity.ok()
@@ -29,7 +34,35 @@ public class ImageController {
     }
 
     @PostMapping("/lists/upload-complete")
-    public void listItemImagesUpload(@RequestBody ListsImagesCreateRequest request) {
+    ResponseEntity<Void> listItemImagesUpload(@RequestBody ListsImagesCreateRequest request) {
         imageService.uploadCompleteItemImages(request.ownerId(), request.listId(), request.extensionRanks());
+        return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/users/upload-url")
+    ResponseEntity<UserPresignedUrlResponse> userImagePresignedUrlCreate(
+            @RequestBody UserImageUpdateRequest request,
+            @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken
+    ) {
+        UserPresignedUrlResponse userPresignedUrlResponse = imageService.updateUserImagePresignedUrl(
+                request.ownerId(),
+                request.profileExtension(),
+                request.backgroundExtension(),
+                accessToken
+        );
+        return ResponseEntity.ok(userPresignedUrlResponse);
+    }
+
+    @PostMapping("/users/upload-complete")
+    ResponseEntity<Void> userImageUpload(
+            @RequestBody UserImageUpdateRequest request
+    ) {
+        imageService.uploadCompleteUserImages(
+                request.ownerId(),
+                request.profileExtension(),
+                request.backgroundExtension()
+        );
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/listywave/image/presentation/dto/request/UserImageUpdateRequest.java
+++ b/src/main/java/com/listywave/image/presentation/dto/request/UserImageUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.listywave.image.presentation.dto.request;
+
+import com.listywave.image.application.domain.ImageFileExtension;
+
+public record UserImageUpdateRequest(
+        Long ownerId,
+        ImageFileExtension profileExtension,
+        ImageFileExtension backgroundExtension
+) {
+}

--- a/src/main/java/com/listywave/image/presentation/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/listywave/image/presentation/dto/response/PresignedUrlResponse.java
@@ -1,7 +1,0 @@
-package com.listywave.image.presentation.dto.response;
-
-public record PresignedUrlResponse(int rank, String presignedUrl) {
-    public static PresignedUrlResponse of(int rank, String presignedUrl){
-        return new PresignedUrlResponse(rank, presignedUrl);
-    }
-}

--- a/src/main/java/com/listywave/user/application/domain/User.java
+++ b/src/main/java/com/listywave/user/application/domain/User.java
@@ -68,6 +68,19 @@ public class User extends BaseEntity {
         );
     }
 
+    public void updateUserImageUrl(String profileImage, String backgroundImage) {
+        if (!profileImage.isEmpty() && backgroundImage.isEmpty()) {
+            this.profileImageUrl = new ProfileImageUrl(profileImage);
+        }
+        if (!backgroundImage.isEmpty() && profileImage.isEmpty()) {
+            this.backgroundImageUrl = new BackgroundImageUrl(backgroundImage);
+        }
+        if (!backgroundImage.isEmpty() && !profileImage.isEmpty()) {
+            this.profileImageUrl = new ProfileImageUrl(profileImage);
+            this.backgroundImageUrl = new BackgroundImageUrl(backgroundImage);
+        }
+    }
+
     public boolean isSame(Long id) {
         return this.id.equals(id);
     }


### PR DESCRIPTION
# Description
 - 사용자의 프로필 이미지와 배경이미지의 Presigned url 발급 요청과 성공 요청을 하나의 API로 묶어달라는 요청으로 인해 경우의수를 나눠 최대한 list생성 시 사용했던 발급 메소드를 재사용 할 수 있도록 로직을 구현하였습니다.

- **프로필 이미지 or 배경이미지가 s3  버킷/basic  경로에 저장된 image url을 사용하고 있을때**
  - 이때는 해당 이미지를 s3에서 삭제 안되도록 구현 
- **프로필 이미지 or 배경이미지 중 하나라도 커스텀 이미지파일을 사용한 경우**
  - 커스텀 이미지 파일이 저장된건 삭제 되며 제 업로드가 됨
  - 프로필 이미지만 변경 시
    - 프로필이미지만 발급됨 , 프로필이미지 경로만 DB에 update됨   
  -  배경이미지만 변경 시
     - 배경이미지만 발급됨, 배경이미지 경로만 DB에 update 됨
  - 둘다 변경 시
    - 둘다 발급됨, 둘다 DB에 update됨
 - **Presigned url 발급 요청 API와 Presigned url 업로드 성공 요청 API 둘다 같이 구현 하였습니다.**
# Reference

# Relation Issues
- close #92 
- close #93
