### PR TITLE
feat: 관련도 정렬을 제외한 리스트 검색 기능 구현

### DIFF
--- a/src/main/java/com/listywave/common/util/StringUtils.java
+++ b/src/main/java/com/listywave/common/util/StringUtils.java
@@ -1,0 +1,10 @@
+package com.listywave.common.util;
+
+import java.util.regex.Pattern;
+
+public class StringUtils {
+
+    public static boolean match(String source, String keyword) {
+        return source.matches(".*" + Pattern.quote(keyword) + ".*");
+    }
+}

--- a/src/main/java/com/listywave/list/application/domain/Lists.java
+++ b/src/main/java/com/listywave/list/application/domain/Lists.java
@@ -1,5 +1,7 @@
 package com.listywave.list.application.domain;
 
+import static com.listywave.common.util.StringUtils.match;
+
 import com.listywave.list.application.dto.ListCreateCommand;
 import com.listywave.list.application.vo.ItemComment;
 import com.listywave.list.application.vo.ItemImageUrl;
@@ -161,6 +163,32 @@ public class Lists {
         }
         addItemToList(lists, items);
         return lists;
+    }
+
+    public boolean isRelatedWith(String keyword) {
+        if (keyword.isBlank()) {
+            return true;
+        }
+        if (match(title.getValue(), keyword)) {
+            return true;
+        }
+        if (labels.stream().anyMatch(label -> match(label.getLabelName(), keyword))) {
+            return true;
+        }
+        if (items.stream().anyMatch(item -> match(item.getTitle(), keyword) || match(item.getComment(), keyword))) {
+            return true;
+        }
+        return false;
+    }
+
+    public boolean isIncluded(CategoryType category) {
+        if (category.equals(CategoryType.ENTIRE)) {
+            return true;
+        }
+        if (this.category.equals(category)) {
+            return true;
+        }
+        return false;
     }
 
     public void sortItems() {

--- a/src/main/java/com/listywave/list/application/domain/SortType.java
+++ b/src/main/java/com/listywave/list/application/domain/SortType.java
@@ -1,0 +1,10 @@
+package com.listywave.list.application.domain;
+
+public enum SortType {
+
+    NEW,
+    OLD,
+    RELATED,
+    COLLECTED,
+    ;
+}

--- a/src/main/java/com/listywave/list/application/dto/response/ListSearchResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/ListSearchResponse.java
@@ -1,0 +1,79 @@
+package com.listywave.list.application.dto.response;
+
+import com.listywave.list.application.domain.Item;
+import com.listywave.list.application.domain.Lists;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ListSearchResponse(
+        List<ListInfo> resultLists,
+        Long totalCount,
+        Long cursorId,
+        boolean hasNext
+) {
+
+    public static ListSearchResponse of(java.util.List<Lists> lists, Long totalCount, Long cursorId, boolean hasNext) {
+        return ListSearchResponse.builder()
+                .resultLists(ListInfo.toList(lists))
+                .totalCount(totalCount)
+                .cursorId(cursorId)
+                .hasNext(hasNext)
+                .build();
+    }
+}
+
+@Builder
+record ListInfo(
+        Long id,
+        String title,
+        java.util.List<ItemInfo> items,
+        boolean isPublic,
+        String backgroundColor,
+        LocalDateTime updatedDate,
+        Long ownerId,
+        String ownerNickname,
+        String ownerProfileImageUrl
+) {
+
+    public static List<ListInfo> toList(java.util.List<Lists> lists) {
+        return lists.stream()
+                .map(ListInfo::of)
+                .toList();
+    }
+
+    private static ListInfo of(Lists lists) {
+        return ListInfo.builder()
+                .id(lists.getId())
+                .title(lists.getTitle())
+                .items(ItemInfo.toList(lists.getItems()))
+                .isPublic(lists.isPublic())
+                .backgroundColor(lists.getBackgroundColor())
+                .updatedDate(lists.getUpdatedDate())
+                .ownerId(lists.getUser().getId())
+                .ownerNickname(lists.getUser().getNickname())
+                .ownerProfileImageUrl(lists.getUser().getProfileImageUrl())
+                .build();
+    }
+}
+
+@Builder
+record ItemInfo(
+        Long id,
+        String title
+) {
+
+    public static java.util.List<ItemInfo> toList(java.util.List<Item> items) {
+        return items.stream()
+                .map(ItemInfo::of)
+                .toList();
+    }
+
+    private static ItemInfo of(Item item) {
+        return ItemInfo.builder()
+                .id(item.getId())
+                .title(item.getTitle())
+                .build();
+    }
+}

--- a/src/main/java/com/listywave/list/presentation/controller/ListController.java
+++ b/src/main/java/com/listywave/list/presentation/controller/ListController.java
@@ -1,9 +1,12 @@
 package com.listywave.list.presentation.controller;
 
+import com.listywave.list.application.domain.CategoryType;
+import com.listywave.list.application.domain.SortType;
 import com.listywave.list.application.dto.ListCreateCommand;
 import com.listywave.list.application.dto.response.ListCreateResponse;
 import com.listywave.list.application.dto.response.ListDetailResponse;
 import com.listywave.list.application.dto.response.ListRecentResponse;
+import com.listywave.list.application.dto.response.ListSearchResponse;
 import com.listywave.list.application.dto.response.ListTrandingResponse;
 import com.listywave.list.application.service.ListService;
 import com.listywave.list.presentation.dto.request.ListCreateRequest;
@@ -18,6 +21,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -66,5 +70,17 @@ public class ListController {
     ) {
         ListRecentResponse recentLists = listService.getRecentLists(accessToken);
         return ResponseEntity.ok(recentLists);
+    }
+
+    @GetMapping("/search")
+    ResponseEntity<ListSearchResponse> search(
+            @RequestParam(value = "keyword", defaultValue = "") String keyword,
+            @RequestParam(value = "sort", defaultValue = "new") SortType sort,
+            @RequestParam(value = "category", defaultValue = "entire") CategoryType category,
+            @RequestParam(value = "size", defaultValue = "5") int size,
+            @RequestParam(value = "cursorId", defaultValue = "0") Long cursorId
+    ) {
+        ListSearchResponse response = listService.search(keyword, sort, category, size, cursorId);
+        return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
# Description
- 관련도 정렬을 제외한 리스트 검색 기능을 구현했습니다.

- 관련도 정렬은 현재 `Lists` 객체를 `List` 로 수정하고, `Lists` 이름의 일급 컬렉션을 만들면 쉽게 구현할 수 있을 것 같아 일단 보류해두었습니다.

- 사실 2차 MVP까지 리스트 검색 기능이 완료되어야 하는데 너무 늦게 구현한 것도 있고 오히려 리팩터링을 하면 더 쉽고 간결하게 코드를 작성할 수 있을 것 같아 결정했습니다.

- Service 로직도 매우 지저분하여 리팩터링 때 함께 작업할 예정입니다.

# Relation Issues
- close #63 
