### PR TITLE
feat: 팔로우 여부 응답에 포함하도록 반영

### DIFF
--- a/src/main/java/com/listywave/auth/application/dto/LoginResponse.java
+++ b/src/main/java/com/listywave/auth/application/dto/LoginResponse.java
@@ -8,6 +8,8 @@ public record LoginResponse(
         String backgroundImageUrl,
         String nickname,
         String description,
+        int followingCount,
+        int followerCount,
         boolean isFirst,
         String accessToken
 ) {
@@ -19,6 +21,8 @@ public record LoginResponse(
                 user.getBackgroundImageUrl(),
                 user.getNickname(),
                 user.getDescription(),
+                user.getFollowingCount(),
+                user.getFollowerCount(),
                 isFirst,
                 accessToken
         );

--- a/src/main/java/com/listywave/auth/application/dto/LoginResponse.java
+++ b/src/main/java/com/listywave/auth/application/dto/LoginResponse.java
@@ -8,8 +8,6 @@ public record LoginResponse(
         String backgroundImageUrl,
         String nickname,
         String description,
-        int followingCount,
-        int followerCount,
         boolean isFirst,
         String accessToken
 ) {
@@ -21,8 +19,6 @@ public record LoginResponse(
                 user.getBackgroundImageUrl(),
                 user.getNickname(),
                 user.getDescription(),
-                user.getFollowingCount(),
-                user.getFollowerCount(),
                 isFirst,
                 accessToken
         );

--- a/src/main/java/com/listywave/user/application/domain/Follow.java
+++ b/src/main/java/com/listywave/user/application/domain/Follow.java
@@ -1,6 +1,7 @@
 package com.listywave.user.application.domain;
 
 import com.listywave.common.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
@@ -18,11 +19,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Follow extends BaseEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "following_user_id")
     private User followingUser;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "follower_user_id")
     private User followerUser;
 }

--- a/src/main/java/com/listywave/user/application/domain/User.java
+++ b/src/main/java/com/listywave/user/application/domain/User.java
@@ -41,12 +41,6 @@ public class User extends BaseEntity {
     @Embedded
     private Description description;
 
-    @Column(nullable = false)
-    private int followingCount;
-
-    @Column(nullable = false)
-    private int followerCount;
-
     @Column(nullable = false, length = 5)
     private Boolean allPrivate;
 
@@ -61,13 +55,11 @@ public class User extends BaseEntity {
                 new BackgroundImageUrl(""),
                 new ProfileImageUrl(""),
                 new Description(""),
-                0,
-                0,
                 false,
                 kakaoAccessToken
         );
     }
-  
+
     public void updateUserProfile(
             String nickname,
             String description,

--- a/src/main/java/com/listywave/user/application/domain/User.java
+++ b/src/main/java/com/listywave/user/application/domain/User.java
@@ -97,6 +97,16 @@ public class User extends BaseEntity {
         return this.id.equals(id);
     }
 
+    public void follow(User followingUser) {
+        this.followingCount++;
+        followingUser.followerCount++;
+    }
+
+    public void unfollow(User followingUser) {
+        this.followingCount--;
+        followingUser.followerCount--;
+    }
+
     public String getNickname() {
         return nickname.getValue();
     }

--- a/src/main/java/com/listywave/user/application/domain/User.java
+++ b/src/main/java/com/listywave/user/application/domain/User.java
@@ -41,6 +41,12 @@ public class User extends BaseEntity {
     @Embedded
     private Description description;
 
+    @Column(nullable = false)
+    private int followingCount;
+
+    @Column(nullable = false)
+    private int followerCount;
+
     @Column(nullable = false, length = 5)
     private Boolean allPrivate;
 
@@ -55,6 +61,8 @@ public class User extends BaseEntity {
                 new BackgroundImageUrl(""),
                 new ProfileImageUrl(""),
                 new Description(""),
+                0,
+                0,
                 false,
                 kakaoAccessToken
         );

--- a/src/main/java/com/listywave/user/application/dto/UserInfoResponse.java
+++ b/src/main/java/com/listywave/user/application/dto/UserInfoResponse.java
@@ -10,8 +10,6 @@ public record UserInfoResponse(
         String profileImageUrl,
         String nickname,
         String description,
-        int followerCount,
-        int followingCount,
         boolean isFollowed,
         boolean isOwner
 ) {
@@ -23,8 +21,6 @@ public record UserInfoResponse(
                 .profileImageUrl(user.getProfileImageUrl())
                 .nickname(user.getNickname())
                 .description(user.getDescription())
-                .followerCount(user.getFollowerCount())
-                .followingCount(user.getFollowingCount())
                 .isFollowed(isFollowed)
                 .isOwner(isOwner)
                 .build();

--- a/src/main/java/com/listywave/user/application/dto/UserInfoResponse.java
+++ b/src/main/java/com/listywave/user/application/dto/UserInfoResponse.java
@@ -10,6 +10,8 @@ public record UserInfoResponse(
         String profileImageUrl,
         String nickname,
         String description,
+        int followingCount,
+        int followerCount,
         boolean isFollowed,
         boolean isOwner
 ) {
@@ -21,6 +23,8 @@ public record UserInfoResponse(
                 .profileImageUrl(user.getProfileImageUrl())
                 .nickname(user.getNickname())
                 .description(user.getDescription())
+                .followingCount(user.getFollowingCount())
+                .followerCount(user.getFollowerCount())
                 .isFollowed(isFollowed)
                 .isOwner(isOwner)
                 .build();

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -34,7 +34,7 @@ public class UserService {
     public UserInfoResponse getUserInfo(Long userId, String accessToken) {
         User user = userRepository.getById(userId);
 
-        if (isSignedIn(accessToken)) {
+        if (isGuest(accessToken)) {
             return UserInfoResponse.of(user, false, false);
         }
 
@@ -42,10 +42,12 @@ public class UserService {
         if (user.isSame(loginUserId)) {
             return UserInfoResponse.of(user, false, true);
         }
-        return UserInfoResponse.of(user, false, false);
+        User loginUser = userRepository.getById(loginUserId);
+        boolean isFollowed = followRepository.existsByFollowerUserAndFollowingUser(loginUser, user);
+        return UserInfoResponse.of(user, isFollowed, false);
     }
 
-    private boolean isSignedIn(String accessToken) {
+    private boolean isGuest(String accessToken) {
         return accessToken.isBlank();
     }
 
@@ -144,7 +146,7 @@ public class UserService {
                 profile.backgroundImageUrl()
         );
     }
-  
+
     @Transactional(readOnly = true)
     public Boolean checkNicknameDuplicate(String nickname, String accessToken) {
         Long loginUserId = jwtManager.read(accessToken);

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -98,6 +98,8 @@ public class UserService {
 
         Follow follow = new Follow(followingUser, followerUser);
         followRepository.save(follow);
+
+        followerUser.follow(followingUser);
     }
 
     public void unfollow(Long followingUserId, String accessToken) {
@@ -107,6 +109,8 @@ public class UserService {
         User followerUser = userRepository.getById(loginUserId);
 
         followRepository.deleteByFollowingUserAndFollowerUser(followingUser, followerUser);
+
+        followerUser.unfollow(followingUser);
     }
 
     public FollowersResponse getFollowers(Long userId, int size, int cursorId) {

--- a/src/main/java/com/listywave/user/repository/follow/FollowRepository.java
+++ b/src/main/java/com/listywave/user/repository/follow/FollowRepository.java
@@ -13,4 +13,6 @@ public interface FollowRepository extends JpaRepository<Follow, Long>, CustomFol
     void deleteByFollowingUserAndFollowerUser(User following, User follower);
 
     int countByFollowingUser(User user);
+
+    boolean existsByFollowerUserAndFollowingUser(User followerUser, User followingUser);
 }


### PR DESCRIPTION
# Description
- 기존, 팔로우 기능이 존재하지 않음에 따라 회원 정보 조회 시에 팔로우 여부에 항상 `false`가 응답하도록 구현했습니다.
  팔로우 기능 구현에 따라 여부를 응답에 반영했습니다.

- ~~User 엔티티에 followingCount와 followerCount 필드를 삭제했습니다.
   본래 성능을 위한 반정규화로 인해 필드를 만들어두었습니다. 하지만 아직 성능을 고려할 단계는 아닐뿐더러 코드 리팩터링 및 테스트 시 보다 용이함을 위해 제거했습니다.
   이로 인해 **Merge하기 전에 `Users` 테이블에 `followingCount`, `followerCount` 칼럼 삭제해야합니다!!!!!!!!!!!!!**~~

- 팔로우 기능 구현에 따라 `User` 엔티티에 있는 `followingCount`와 `followerCount`를 변경하는 기능도 함께 구현했습니다.

# Relation Issues
- close #46 
