### PR TITLE
feat: 인증 정보 Required로 반영 및 인가 기능 구현

### DIFF
--- a/src/main/java/com/listywave/auth/application/domain/JwtManager.java
+++ b/src/main/java/com/listywave/auth/application/domain/JwtManager.java
@@ -30,9 +30,10 @@ public class JwtManager {
     }
 
     public Long read(String token) {
-        if (token.isBlank()) {
+        if (token.isBlank() || !token.startsWith("Bearer ")) {
             throw new CustomException(REQUIRED_ACCESS_TOKEN);
         }
+        token = token.substring(7);
 
         String subject = Jwts.parser()
                 .verifyWith(key)

--- a/src/main/java/com/listywave/list/application/domain/Comment.java
+++ b/src/main/java/com/listywave/list/application/domain/Comment.java
@@ -38,6 +38,10 @@ public class Comment extends BaseEntity {
         return new Comment(list, user, new Content(content), false);
     }
 
+    public boolean canDeleteBy(User user) {
+        return this.user.equals(user);
+    }
+
     public void softDelete() {
         this.isDeleted = true;
     }

--- a/src/main/java/com/listywave/list/application/domain/ListEntity.java
+++ b/src/main/java/com/listywave/list/application/domain/ListEntity.java
@@ -196,6 +196,10 @@ public class ListEntity {
         this.getItems().sort(Comparator.comparing(Item::getRanking));
     }
 
+    public boolean canDeleteBy(User user) {
+        return this.user.equals(user);
+    }
+
     public String getCategoryName() {
         return category.name();
     }

--- a/src/main/java/com/listywave/list/application/domain/Reply.java
+++ b/src/main/java/com/listywave/list/application/domain/Reply.java
@@ -30,6 +30,10 @@ public class Reply extends BaseEntity {
     @Embedded
     private Content content;
 
+    public boolean canDeleteBy(User user) {
+        return this.user.equals(user);
+    }
+
     public Long getCommentId() {
         return comment.getId();
     }

--- a/src/main/java/com/listywave/list/presentation/controller/CommentController.java
+++ b/src/main/java/com/listywave/list/presentation/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.listywave.list.presentation.controller;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import com.listywave.list.application.dto.response.CommentCreateResponse;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,10 +29,10 @@ public class CommentController {
     @PostMapping
     ResponseEntity<CommentCreateResponse> create(
             @PathVariable(value = "listId") Long listId,
-//            @RequestHeader(value = "Authorization", defaultValue = "") String accessToken,
+            @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken,
             @RequestBody CommentCreateRequest commentCreateRequest
     ) {
-        CommentCreateResponse response = commentService.create(listId, commentCreateRequest.content());
+        CommentCreateResponse response = commentService.create(listId, commentCreateRequest.content(), accessToken);
         return ResponseEntity.status(CREATED).body(response);
     }
 
@@ -47,10 +49,10 @@ public class CommentController {
     @DeleteMapping("/{commentId}")
     ResponseEntity<Void> delete(
             @PathVariable(value = "listId") Long listId,
-//            @RequestHeader(value = "Authorization", defaultValue = "") String accessToken,
+            @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken,
             @PathVariable(value = "commentId") Long commentId
     ) {
-        commentService.delete(listId, commentId);
+        commentService.delete(listId, commentId, accessToken);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/listywave/list/presentation/controller/ListController.java
+++ b/src/main/java/com/listywave/list/presentation/controller/ListController.java
@@ -1,5 +1,7 @@
 package com.listywave.list.presentation.controller;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
 import com.listywave.list.application.domain.CategoryType;
 import com.listywave.list.application.domain.SortType;
 import com.listywave.list.application.dto.ListCreateCommand;
@@ -59,8 +61,11 @@ public class ListController {
     }
 
     @DeleteMapping("/{listId}")
-    ResponseEntity<Void> deleteList(@PathVariable(value = "listId") Long listId) {
-        listService.deleteList(listId);
+    ResponseEntity<Void> deleteList(
+            @PathVariable(value = "listId") Long listId,
+            @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken
+    ) {
+        listService.deleteList(listId, accessToken);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/listywave/list/presentation/controller/ReplyController.java
+++ b/src/main/java/com/listywave/list/presentation/controller/ReplyController.java
@@ -1,5 +1,6 @@
 package com.listywave.list.presentation.controller;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import com.listywave.list.application.dto.ReplyDeleteCommand;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,10 +28,10 @@ public class ReplyController {
     ResponseEntity<ReplyCreateResponse> create(
             @PathVariable(value = "listId") Long listId,
             @PathVariable(value = "commentId") Long commentId,
-//            @RequestHeader(value = "Authorization", defaultValue = "") String accessToken,
+            @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken,
             @RequestBody ReplyCreateRequest request
     ) {
-        ReplyCreateResponse response = replyService.createReply(listId, commentId, request.content());
+        ReplyCreateResponse response = replyService.createReply(listId, commentId, request.content(), accessToken);
         return ResponseEntity.status(CREATED).body(response);
     }
 
@@ -37,11 +39,11 @@ public class ReplyController {
     ResponseEntity<Void> deleteReply(
             @PathVariable(value = "listId") Long listId,
             @PathVariable(value = "commentId") Long commentId,
-            @PathVariable(value = "replyId") Long replyId
-//            @RequestHeader(value = "Authorization", defaultValue = "") String accessToken
+            @PathVariable(value = "replyId") Long replyId,
+            @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken
     ) {
         ReplyDeleteCommand replyDeleteCommand = new ReplyDeleteCommand(listId, commentId, replyId);
-        replyService.delete(replyDeleteCommand);
+        replyService.delete(replyDeleteCommand, accessToken);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/listywave/list/repository/reply/ReplyRepository.java
+++ b/src/main/java/com/listywave/list/repository/reply/ReplyRepository.java
@@ -1,11 +1,18 @@
 package com.listywave.list.repository.reply;
 
+import static com.listywave.common.exception.ErrorCode.RESOURCE_NOT_FOUND;
+
+import com.listywave.common.exception.CustomException;
 import com.listywave.list.application.domain.Comment;
 import com.listywave.list.application.domain.Reply;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReplyRepository extends JpaRepository<Reply, Long>, CustomReplyRepository {
+
+    default Reply getById(Long id) {
+        return findById(id).orElseThrow(() -> new CustomException(RESOURCE_NOT_FOUND, "존재하지 않는 답글입니다."));
+    }
 
     boolean existsByComment(Comment comment);
 


### PR DESCRIPTION
# Description
1. 리스트 및 댓글, 답글 삭제 및 수정 시에 인증 정보가 반드시 포함되도록 수정했습니다. 동시에 인가 기능도 구현했습니다.
2. AccessToken 앞에 "Bearer " Prefix가 포함되도록 수정했습니다.

# Relation Issues
- close #112 
- close #108