### PR TITLE
feat: 콜렉션 Enitity생성 및 콜렉트 담기 및 취소 API 구현

### DIFF
--- a/src/main/java/com/listywave/collection/application/domain/Collect.java
+++ b/src/main/java/com/listywave/collection/application/domain/Collect.java
@@ -12,13 +12,11 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Builder
 @AllArgsConstructor
 @Table(name = "collection")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,10 +33,8 @@ public class Collect {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    public static Collect createCollection(ListEntity list, Long userId) {
-        return Collect.builder()
-                .list(list)
-                .userId(userId)
-                .build();
+    public Collect(ListEntity list, Long userId) {
+        this.list = list;
+        this.userId = userId;
     }
 }

--- a/src/main/java/com/listywave/collection/application/domain/Collect.java
+++ b/src/main/java/com/listywave/collection/application/domain/Collect.java
@@ -1,0 +1,44 @@
+package com.listywave.collection.application.domain;
+
+import com.listywave.list.application.domain.ListEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@Table(name = "collection")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Collect {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "list_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ListEntity list;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    public static Collect createCollection(ListEntity list, Long userId) {
+        return Collect.builder()
+                .list(list)
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/main/java/com/listywave/collection/application/service/CollectionService.java
+++ b/src/main/java/com/listywave/collection/application/service/CollectionService.java
@@ -1,0 +1,66 @@
+package com.listywave.collection.application.service;
+
+import com.listywave.auth.application.domain.JwtManager;
+import com.listywave.collection.application.domain.Collect;
+import com.listywave.collection.repository.CollectionRepository;
+import com.listywave.common.exception.CustomException;
+import com.listywave.common.exception.ErrorCode;
+import com.listywave.list.application.domain.ListEntity;
+import com.listywave.list.repository.list.ListRepository;
+import com.listywave.user.application.domain.User;
+import com.listywave.user.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CollectionService {
+
+    private final JwtManager jwtManager;
+    private final UserRepository userRepository;
+    private final ListRepository listRepository;
+    private final CollectionRepository collectionRepository;
+
+    public void collectOrCancel(Long userId, Long listId, String accessToken) {
+        Long tokenUserId = jwtManager.read(accessToken);
+        validateUserIdInAccessToken(userId, tokenUserId);
+
+        User user = userRepository.getById(tokenUserId);
+        ListEntity list = findListById(listId);
+
+        if (isCollected(list, user.getId())) {
+            cancelCollect(list, user.getId());
+        } else {
+            addCollect(list, user.getId());
+        }
+    }
+
+    private void addCollect(ListEntity list, Long userId) {
+        Collect collection = Collect.createCollection(list, userId);
+        collectionRepository.save(collection);
+        list.incrementCollectCount();
+    }
+
+    private void cancelCollect(ListEntity list, Long userId) {
+        collectionRepository.deleteByListAndUserId(list, userId);
+        list.decrementCollectCount();
+    }
+
+    private boolean isCollected(ListEntity list, Long userId) {
+        return collectionRepository.existsByListAndUserId(list, userId);
+    }
+
+    private void validateUserIdInAccessToken(Long userId, Long tokenUserId) {
+        if (!userId.equals(tokenUserId)) {
+            throw new CustomException(ErrorCode.ACCESS_TOKEN_USER_MISMATCH);
+        }
+    }
+
+    private ListEntity findListById(Long listId) {
+        return listRepository
+                .findById(listId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND, "존재하지 않는 리스트입니다."));
+    }
+}

--- a/src/main/java/com/listywave/collection/application/service/CollectionService.java
+++ b/src/main/java/com/listywave/collection/application/service/CollectionService.java
@@ -30,10 +30,18 @@ public class CollectionService {
         User user = userRepository.getById(tokenUserId);
         ListEntity list = findListById(listId);
 
+        cannotCollectByOwner(user.getId(), list.getUser().getId());
+
         if (isCollected(list, user.getId())) {
             cancelCollect(list, user.getId());
         } else {
             addCollect(list, user.getId());
+        }
+    }
+
+    private void cannotCollectByOwner(Long userId, Long ownerId) {
+        if (userId.equals(ownerId)) {
+            throw new CustomException(ErrorCode.CANNOT_COLLECT_OWN_LIST);
         }
     }
 

--- a/src/main/java/com/listywave/collection/presentation/controller/CollectionController.java
+++ b/src/main/java/com/listywave/collection/presentation/controller/CollectionController.java
@@ -16,13 +16,12 @@ public class CollectionController {
 
     private final CollectionService collectionService;
 
-    @PostMapping("/collect/{userId}/{listId}")
+    @PostMapping("/lists/{listId}/collect")
     ResponseEntity<Void> collectOrCancel(
-            @PathVariable("userId") Long userId,
             @PathVariable("listId") Long listId,
             @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken
     ) {
-        collectionService.collectOrCancel(userId, listId, accessToken);
+        collectionService.collectOrCancel(listId, accessToken);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/listywave/collection/presentation/controller/CollectionController.java
+++ b/src/main/java/com/listywave/collection/presentation/controller/CollectionController.java
@@ -1,0 +1,28 @@
+package com.listywave.collection.presentation.controller;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import com.listywave.collection.application.service.CollectionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CollectionController {
+
+    private final CollectionService collectionService;
+
+    @PostMapping("/collect/{userId}/{listId}")
+    ResponseEntity<Void> collectOrCancel(
+            @PathVariable("userId") Long userId,
+            @PathVariable("listId") Long listId,
+            @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken
+    ) {
+        collectionService.collectOrCancel(userId, listId, accessToken);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/listywave/collection/repository/CollectionRepository.java
+++ b/src/main/java/com/listywave/collection/repository/CollectionRepository.java
@@ -5,6 +5,7 @@ import com.listywave.list.application.domain.ListEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CollectionRepository extends JpaRepository<Collect, Long> {
+
     boolean existsByListAndUserId(ListEntity list, Long userId);
 
     void deleteByListAndUserId(ListEntity list, Long userId);

--- a/src/main/java/com/listywave/collection/repository/CollectionRepository.java
+++ b/src/main/java/com/listywave/collection/repository/CollectionRepository.java
@@ -1,0 +1,11 @@
+package com.listywave.collection.repository;
+
+import com.listywave.collection.application.domain.Collect;
+import com.listywave.list.application.domain.ListEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CollectionRepository extends JpaRepository<Collect, Long> {
+    boolean existsByListAndUserId(ListEntity list, Long userId);
+
+    void deleteByListAndUserId(ListEntity list, Long userId);
+}

--- a/src/main/java/com/listywave/common/exception/ErrorCode.java
+++ b/src/main/java/com/listywave/common/exception/ErrorCode.java
@@ -19,8 +19,7 @@ public enum ErrorCode {
     REQUIRED_ACCESS_TOKEN(UNAUTHORIZED, "인증 정보가 필요합니다."),
     INVALID_ACCESS_TOKEN(UNAUTHORIZED, "유효하지 않은 AccessToken 입니다. 다시 로그인해주세요."),
     INVALID_ACCESS(FORBIDDEN, "접근 권한이 존재하지 않습니다."),
-    ACCESS_TOKEN_USER_MISMATCH(UNAUTHORIZED, "AccessToken과 사용자가 일치하지 않습니다."),
-    CANNOT_COLLECT_OWN_LIST(FORBIDDEN, "리스트 작성자는 자신의 리스트에 콜렉트할 수 없습니다."),
+    CANNOT_COLLECT_OWN_LIST(BAD_REQUEST, "리스트 작성자는 자신의 리스트에 콜렉트할 수 없습니다."),
 
     // Http Request
     METHOD_ARGUMENT_TYPE_MISMATCH(BAD_REQUEST, "요청 한 값 타입이 잘못되어 binding에 실패하였습니다."),

--- a/src/main/java/com/listywave/common/exception/ErrorCode.java
+++ b/src/main/java/com/listywave/common/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     INVALID_ACCESS_TOKEN(UNAUTHORIZED, "유효하지 않은 AccessToken 입니다. 다시 로그인해주세요."),
     INVALID_ACCESS(FORBIDDEN, "접근 권한이 존재하지 않습니다."),
     ACCESS_TOKEN_USER_MISMATCH(UNAUTHORIZED, "AccessToken과 사용자가 일치하지 않습니다."),
+    CANNOT_COLLECT_OWN_LIST(FORBIDDEN, "리스트 작성자는 자신의 리스트에 콜렉트할 수 없습니다."),
 
     // Http Request
     METHOD_ARGUMENT_TYPE_MISMATCH(BAD_REQUEST, "요청 한 값 타입이 잘못되어 binding에 실패하였습니다."),

--- a/src/main/java/com/listywave/common/exception/ErrorCode.java
+++ b/src/main/java/com/listywave/common/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     REQUIRED_ACCESS_TOKEN(UNAUTHORIZED, "인증 정보가 필요합니다."),
     INVALID_ACCESS_TOKEN(UNAUTHORIZED, "유효하지 않은 AccessToken 입니다. 다시 로그인해주세요."),
     INVALID_ACCESS(FORBIDDEN, "접근 권한이 존재하지 않습니다."),
+    ACCESS_TOKEN_USER_MISMATCH(UNAUTHORIZED, "AccessToken과 사용자가 일치하지 않습니다."),
 
     // Http Request
     METHOD_ARGUMENT_TYPE_MISMATCH(BAD_REQUEST, "요청 한 값 타입이 잘못되어 binding에 실패하였습니다."),

--- a/src/main/java/com/listywave/list/application/domain/ListEntity.java
+++ b/src/main/java/com/listywave/list/application/domain/ListEntity.java
@@ -200,6 +200,14 @@ public class ListEntity {
         return this.user.equals(user);
     }
 
+    public void incrementCollectCount() {
+        this.collectCount++;
+    }
+
+    public void decrementCollectCount() {
+        this.collectCount--;
+    }
+
     public String getCategoryName() {
         return category.name();
     }


### PR DESCRIPTION
# Description
- **Collection Entity를 생성하였으며 User와 관계를 맺지 않은 이유**
-> _해당 서비스에서 Collection은 사용자에 대한 콜렉션 조회와 해당 리스트에대한 콜렉트 담기/취소 기능에 대해서 사용되기에 User와의 관계를 넣는 것은 불필요하다고 판단하였고, 데이터베이스 정규화 원칙을 준수하면서도 효율적으로 데이터를 저장하고 관리하는 데 도움이 된다 생각했습니다!_
- **토글방식으로 콜렉트 담기/취소 API를 구현했습니다!**
# Reference
https://www.erdcloud.com/d/akmiXqDgrioYjsYm3
# Relation Issues
- close #117 
