### PR TITLE
feat: 리스트 수정 API 및 아이템 이미지 삭제 API 구현

### DIFF
--- a/src/main/java/com/listywave/history/application/domain/History.java
+++ b/src/main/java/com/listywave/history/application/domain/History.java
@@ -1,0 +1,57 @@
+package com.listywave.history.application.domain;
+
+import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static jakarta.persistence.TemporalType.TIMESTAMP;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.listywave.list.application.domain.list.ListEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Temporal;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
+public class History {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "list_id")
+    private ListEntity list;
+
+    @OneToMany(mappedBy = "history", fetch = LAZY, cascade = ALL, orphanRemoval = true)
+    private List<HistoryItem> items;
+
+    @Temporal(TIMESTAMP)
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdDate;
+
+    @Column(nullable = false)
+    private boolean isPublic;
+
+    public History(ListEntity list, List<HistoryItem> historyItems, LocalDateTime updatedDate, boolean isPublic) {
+        this.list = list;
+        this.items = updateHistory(historyItems);
+        this.createdDate = updatedDate;
+        this.isPublic = isPublic;
+    }
+
+    private List<HistoryItem> updateHistory(List<HistoryItem> historyItems) {
+        historyItems.forEach(historyItem -> historyItem.updateHistory(this));
+        return historyItems;
+    }
+}

--- a/src/main/java/com/listywave/history/application/domain/HistoryItem.java
+++ b/src/main/java/com/listywave/history/application/domain/HistoryItem.java
@@ -1,0 +1,43 @@
+package com.listywave.history.application.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
+public class HistoryItem {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "history_id")
+    private History history;
+
+    @Column(nullable = false, updatable = false)
+    private int rank;
+
+    @Embedded
+    private HistoryItemTitle title;
+
+    public HistoryItem(int rank, HistoryItemTitle title) {
+        this(null, null, rank, title);
+    }
+
+    public void updateHistory(History history) {
+        this.history = history;
+    }
+}

--- a/src/main/java/com/listywave/history/application/domain/HistoryItemTitle.java
+++ b/src/main/java/com/listywave/history/application/domain/HistoryItemTitle.java
@@ -1,34 +1,30 @@
-package com.listywave.list.application.domain.item;
+package com.listywave.history.application.domain;
 
 import static com.listywave.common.exception.ErrorCode.LENGTH_EXCEEDED;
+import static lombok.AccessLevel.PROTECTED;
 
 import com.listywave.common.exception.CustomException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @Embeddable
-@EqualsAndHashCode
-@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
-public class ItemTitle {
+@NoArgsConstructor(access = PROTECTED, force = true)
+public class HistoryItemTitle {
 
     private static final int MAX_LENGTH = 100;
 
-    @Column(name = "title", nullable = false, length = MAX_LENGTH)
+    @Column(name = "title", length = MAX_LENGTH, updatable = false)
     private final String value;
 
-    public ItemTitle(String value) {
-        validate(value);
+    public HistoryItemTitle(String value) {
+        validateLength(value);
         this.value = value;
     }
 
-    private void validate(String value) {
+    private void validateLength(String value) {
         if (value.length() > MAX_LENGTH) {
             throw new CustomException(LENGTH_EXCEEDED, "아이템 제목은 " + MAX_LENGTH + "자를 넘을 수 없습니다.");
         }

--- a/src/main/java/com/listywave/history/repository/HistoryRepository.java
+++ b/src/main/java/com/listywave/history/repository/HistoryRepository.java
@@ -1,0 +1,7 @@
+package com.listywave.history.repository;
+
+import com.listywave.history.application.domain.History;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HistoryRepository extends JpaRepository<History, Long> {
+}

--- a/src/main/java/com/listywave/image/application/dto/ExtensionRanks.java
+++ b/src/main/java/com/listywave/image/application/dto/ExtensionRanks.java
@@ -2,5 +2,8 @@ package com.listywave.image.application.dto;
 
 import com.listywave.image.application.domain.ImageFileExtension;
 
-public record ExtensionRanks(int rank, ImageFileExtension extension) {
+public record ExtensionRanks(
+        int rank,
+        ImageFileExtension extension
+) {
 }

--- a/src/main/java/com/listywave/image/application/service/ImageService.java
+++ b/src/main/java/com/listywave/image/application/service/ImageService.java
@@ -1,6 +1,7 @@
 package com.listywave.image.application.service;
 
 import static com.listywave.common.exception.ErrorCode.S3_DELETE_OBJECTS_EXCEPTION;
+import static com.listywave.image.application.domain.ImageType.LISTS_ITEM;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.HttpMethod;
@@ -57,7 +58,6 @@ public class ImageService {
     private final UserRepository userRepository;
 
     public List<ItemPresignedUrlResponse> createListsPresignedUrl(Long ownerId, Long listId, List<ExtensionRanks> extensionRanks) {
-
         //TODO: 회원이 존재하는지 않하는지 검증 (security)
         final User user = userUtil.getUserByUserid(ownerId);
 
@@ -68,12 +68,7 @@ public class ImageService {
                 .map((extensionRank) -> {
                             String imageKey = generatedUUID();
                             GeneratePresignedUrlRequest generatePresignedUrlRequest =
-                                    getGeneratePresignedUrl(
-                                            ImageType.LISTS_ITEM,
-                                            listId,
-                                            imageKey,
-                                            extensionRank.extension()
-                                    );
+                                    getGeneratePresignedUrl(LISTS_ITEM, listId, imageKey, extensionRank.extension());
                             updateItemImageKey(listId, extensionRank, imageKey);
 
                             return ItemPresignedUrlResponse.of(
@@ -94,12 +89,7 @@ public class ImageService {
         extensionRanks.forEach(
                 extensionRank -> {
                     Item item = findItem(listId, extensionRank.rank());
-                    String imageUrl = createReadImageUrl(
-                            ImageType.LISTS_ITEM,
-                            listId,
-                            item.getImageKey(),
-                            extensionRank.extension()
-                    );
+                    String imageUrl = createReadImageUrl(LISTS_ITEM, listId, item.getImageKey(), extensionRank.extension());
                     item.updateItemImageUrl(imageUrl);
                 }
         );
@@ -207,20 +197,20 @@ public class ImageService {
         }
     }
 
-    private void deleteImageFile(String fileFullPath) {
-        try {
-            amazonS3.deleteObject(bucket, fileFullPath);
-        } catch (AmazonServiceException e) {
-            throw new CustomException(ErrorCode.S3_DELETE_OBJECTS_EXCEPTION);
-        }
-    }
-
     private boolean isCustomUserImage(String url) {
         if (url.split("/").length >= 4) {
             String type = url.split("/")[3];
             return !type.equals("basic");
         }
         return false;
+    }
+
+    private void deleteImageFile(String fileFullPath) {
+        try {
+            amazonS3.deleteObject(bucket, fileFullPath);
+        } catch (AmazonServiceException e) {
+            throw new CustomException(ErrorCode.S3_DELETE_OBJECTS_EXCEPTION);
+        }
     }
 
     private String getFileFullName(String url) {
@@ -339,6 +329,23 @@ public class ImageService {
     }
 
 
+    private String createFileName(
+            ImageType imageType,
+            Long targetId,
+            String imageKey,
+            ImageFileExtension imageFileExtension
+    ) {
+        return getCurrentProfile()
+                + "/"
+                + imageType.getValue()
+                + "/"
+                + targetId
+                + "/"
+                + imageKey
+                + "."
+                + imageFileExtension.getUploadExtension();
+    }
+
     private String createReadImageUrl(
             ImageType imageType,
             Long targetId,
@@ -358,36 +365,19 @@ public class ImageService {
                 + imageFileExtension.getUploadExtension();
     }
 
-    private String createFileName(
-            ImageType imageType,
-            Long targetId,
-            String imageKey,
-            ImageFileExtension imageFileExtension
-    ) {
-        return getCurrentProfile()
-                + "/"
-                + imageType.getValue()
-                + "/"
-                + targetId
-                + "/"
-                + imageKey
-                + "."
-                + imageFileExtension.getUploadExtension();
-    }
-
     private void updateItemImageKey(Long listId, ExtensionRanks extensionRank, String imageKey) {
         findItem(listId, extensionRank.rank())
                 .updateItemImageKey(imageKey);
-    }
-
-    private void updateUserImageKey(User user, String profileImageKey, String backgroundImageKey) {
-        user.updateUserImageUrl(profileImageKey, backgroundImageKey);
     }
 
     private Item findItem(Long listId, int rank) {
         return itemRepository
                 .findByListIdAndRanking(listId, rank)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND, "해당 아이템이 존재하지 않습니다."));
+    }
+
+    private void updateUserImageKey(User user, String profileImageKey, String backgroundImageKey) {
+        user.updateUserImageUrl(profileImageKey, backgroundImageKey);
     }
 
     private GeneratePresignedUrlRequest createGeneratePreSignedUrlRequest(

--- a/src/main/java/com/listywave/image/presentation/controller/ImageController.java
+++ b/src/main/java/com/listywave/image/presentation/controller/ImageController.java
@@ -10,6 +10,8 @@ import com.listywave.image.presentation.dto.request.UserImageUpdateRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -25,12 +27,12 @@ public class ImageController {
     ResponseEntity<List<ItemPresignedUrlResponse>> listItemPresignedUrlCreate(
             @RequestBody ListsImagesCreateRequest request
     ) {
-        return ResponseEntity.ok()
-                .body(imageService.createListsPresignedUrl(
-                        request.ownerId(),
-                        request.listId(),
-                        request.extensionRanks()
-                ));
+        List<ItemPresignedUrlResponse> response = imageService.createListsPresignedUrl(
+                request.ownerId(),
+                request.listId(),
+                request.extensionRanks()
+        );
+        return ResponseEntity.ok().body(response);
     }
 
     @PostMapping("/lists/upload-complete")
@@ -62,6 +64,16 @@ public class ImageController {
                 request.profileExtension(),
                 request.backgroundExtension()
         );
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/lists/{listId}/items/{itemId}")
+    ResponseEntity<Void> deleteImageOfItem(
+            @PathVariable("listId") Long listId,
+            @PathVariable("itemId") Long itemId,
+            @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken
+    ) {
+        imageService.deleteImageOfItem(listId, itemId, accessToken);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/listywave/image/presentation/controller/ImageController.java
+++ b/src/main/java/com/listywave/image/presentation/controller/ImageController.java
@@ -64,5 +64,4 @@ public class ImageController {
         );
         return ResponseEntity.noContent().build();
     }
-
 }

--- a/src/main/java/com/listywave/image/presentation/dto/request/ListsImagesCreateRequest.java
+++ b/src/main/java/com/listywave/image/presentation/dto/request/ListsImagesCreateRequest.java
@@ -3,5 +3,9 @@ package com.listywave.image.presentation.dto.request;
 import com.listywave.image.application.dto.ExtensionRanks;
 import java.util.List;
 
-public record ListsImagesCreateRequest(Long ownerId, Long listId, List<ExtensionRanks> extensionRanks) {
+public record ListsImagesCreateRequest(
+        Long ownerId,
+        Long listId,
+        List<ExtensionRanks> extensionRanks
+) {
 }

--- a/src/main/java/com/listywave/list/application/domain/item/Item.java
+++ b/src/main/java/com/listywave/list/application/domain/item/Item.java
@@ -4,12 +4,15 @@ import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.listywave.common.BaseEntity;
+import com.listywave.history.application.domain.HistoryItem;
+import com.listywave.history.application.domain.HistoryItemTitle;
 import com.listywave.list.application.domain.list.ListEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -57,5 +60,22 @@ public class Item extends BaseEntity {
 
     public void updateList(ListEntity list) {
         this.list = list;
+    }
+
+    public HistoryItem toHistoryItem() {
+        return new HistoryItem(this.ranking, new HistoryItemTitle(this.title.getValue()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Item item = (Item) o;
+        return getRanking() == item.getRanking() && Objects.equals(getTitle(), item.getTitle()) && Objects.equals(getComment(), item.getComment()) && Objects.equals(getLink(), item.getLink()) && Objects.equals(getImageUrl(), item.getImageUrl()) && Objects.equals(getImageKey(), item.getImageKey());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getRanking(), getTitle(), getComment(), getLink(), getImageUrl(), getImageKey());
     }
 }

--- a/src/main/java/com/listywave/list/application/domain/item/Items.java
+++ b/src/main/java/com/listywave/list/application/domain/item/Items.java
@@ -3,15 +3,21 @@ package com.listywave.list.application.domain.item;
 import static com.listywave.common.exception.ErrorCode.INVALID_COUNT;
 import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.FetchType.LAZY;
+import static java.util.stream.Collectors.toMap;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.listywave.common.exception.CustomException;
+import com.listywave.history.application.domain.HistoryItem;
 import com.listywave.list.application.domain.list.ListEntity;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import lombok.NoArgsConstructor;
 
 @Embeddable
@@ -53,14 +59,93 @@ public class Items {
     }
 
     public Items updateList(ListEntity list) {
-        for (Item item : values) {
-            item.updateList(list);
-        }
+        values.forEach(item -> item.updateList(list));
         return new Items(values);
+    }
+
+    public boolean canCreateHistory(Items newItems) {
+        if (this.size() != newItems.size()) {
+            return true;
+        }
+
+        Map<ItemTitle, Integer> before = this.mapTitleAndRank();
+        Map<ItemTitle, Integer> updated = newItems.mapTitleAndRank();
+
+        for (var entry : before.entrySet()) {
+            ItemTitle beforeTitle = entry.getKey();
+            Integer beforeRank = entry.getValue();
+
+            if (!updated.containsKey(beforeTitle)) {
+                return true;
+            }
+            Integer updatedRank = updated.get(beforeTitle);
+            if (!beforeRank.equals(updatedRank)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Map<ItemTitle, Integer> mapTitleAndRank() {
+        return sortByRank().getValues().stream()
+                .collect(toMap(
+                        Item::getTitle,
+                        Item::getRanking,
+                        (item1, item2) -> item2,
+                        LinkedHashMap::new
+                ));
+    }
+
+    public Item get(int index) {
+        return values.get(index);
+    }
+
+    public int size() {
+        return values.size();
+    }
+
+    public List<HistoryItem> toHistoryItems() {
+        return values.stream()
+                .map(Item::toHistoryItem)
+                .toList();
     }
 
     public List<Item> getValues() {
         return new ArrayList<>(values);
+    }
+
+    public boolean isChange(Items newItems) {
+        if (this.size() != newItems.size()) {
+            return true;
+        }
+
+        for (int i = 0; i < this.size(); i++) {
+            Item beforeItem = this.get(i);
+            Item newItem = newItems.get(i);
+
+            if (!beforeItem.equals(newItem)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void updateAll(Items newItems, ListEntity list) {
+        removeDeleteItems(newItems);
+        addNewItems(newItems, list);
+    }
+
+    private void removeDeleteItems(Items newItems) {
+        Set<Item> beforeLabels = new HashSet<>(this.values);
+        newItems.values.forEach(beforeLabels::remove);
+        this.values.removeAll(beforeLabels);
+    }
+
+    private void addNewItems(Items newItems, ListEntity list) {
+        Set<Item> newItemsSet = new HashSet<>(newItems.values);
+        this.values.forEach(newItemsSet::remove);
+        newItemsSet.forEach(newItem -> newItem.updateList(list));
+        this.values.addAll(newItemsSet);
     }
 
 //    public Items sortByRankTop3() {
@@ -68,5 +153,4 @@ public class Items {
 //                .toList();
 //        return new Items(sorted);
 //    }
-
 }

--- a/src/main/java/com/listywave/list/application/domain/item/Items.java
+++ b/src/main/java/com/listywave/list/application/domain/item/Items.java
@@ -96,22 +96,10 @@ public class Items {
                 ));
     }
 
-    public Item get(int index) {
-        return values.get(index);
-    }
-
-    public int size() {
-        return values.size();
-    }
-
     public List<HistoryItem> toHistoryItems() {
         return values.stream()
                 .map(Item::toHistoryItem)
                 .toList();
-    }
-
-    public List<Item> getValues() {
-        return new ArrayList<>(values);
     }
 
     public boolean isChange(Items newItems) {
@@ -152,9 +140,15 @@ public class Items {
         return this.values.contains(item);
     }
 
-//    public Items sortByRankTop3() {
-//        List<Item> sorted = values.stream().sorted(Comparator.comparing(Item::getRanking))
-//                .toList();
-//        return new Items(sorted);
-//    }
+    public Item get(int index) {
+        return values.get(index);
+    }
+
+    public int size() {
+        return values.size();
+    }
+
+    public List<Item> getValues() {
+        return new ArrayList<>(values);
+    }
 }

--- a/src/main/java/com/listywave/list/application/domain/item/Items.java
+++ b/src/main/java/com/listywave/list/application/domain/item/Items.java
@@ -2,7 +2,7 @@ package com.listywave.list.application.domain.item;
 
 import static com.listywave.common.exception.ErrorCode.INVALID_COUNT;
 import static jakarta.persistence.CascadeType.ALL;
-import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.FetchType.EAGER;
 import static java.util.stream.Collectors.toMap;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -27,7 +27,7 @@ public class Items {
     private static final int MIN_SIZE = 3;
     private static final int MAX_SIZE = 10;
 
-    @OneToMany(fetch = LAZY, mappedBy = "list", cascade = ALL, orphanRemoval = true)
+    @OneToMany(fetch = EAGER, mappedBy = "list", cascade = ALL, orphanRemoval = true)
     private final List<Item> values;
 
     public Items(List<Item> items) {
@@ -146,6 +146,10 @@ public class Items {
         this.values.forEach(newItemsSet::remove);
         newItemsSet.forEach(newItem -> newItem.updateList(list));
         this.values.addAll(newItemsSet);
+    }
+
+    public boolean contains(Item item) {
+        return this.values.contains(item);
     }
 
 //    public Items sortByRankTop3() {

--- a/src/main/java/com/listywave/list/application/domain/label/Label.java
+++ b/src/main/java/com/listywave/list/application/domain/label/Label.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -50,5 +51,18 @@ public class Label {
 
     public String getName() {
         return name.getValue();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Label label = (Label) o;
+        return Objects.equals(getName(), label.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName());
     }
 }

--- a/src/main/java/com/listywave/list/application/domain/label/Labels.java
+++ b/src/main/java/com/listywave/list/application/domain/label/Labels.java
@@ -3,6 +3,7 @@ package com.listywave.list.application.domain.label;
 import static com.listywave.common.exception.ErrorCode.INVALID_COUNT;
 import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.FetchType.LAZY;
+import static java.util.stream.Collectors.toSet;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.listywave.common.exception.CustomException;
@@ -10,7 +11,9 @@ import com.listywave.list.application.domain.list.ListEntity;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.NoArgsConstructor;
 
 @Embeddable
@@ -39,10 +42,47 @@ public class Labels {
     }
 
     public Labels updateList(ListEntity list) {
-        for (Label label : values) {
-            label.updateList(list);
-        }
+        values.forEach(label -> label.updateList(list));
         return new Labels(values);
+    }
+
+    public boolean isChange(Labels newLabels) {
+        Set<String> beforeLabelNames = this.values.stream()
+                .map(Label::getName)
+                .collect(toSet());
+
+        Set<String> newLabelNames = newLabels.values.stream()
+                .map(Label::getName)
+                .collect(toSet());
+
+        if (beforeLabelNames.size() != newLabelNames.size()) {
+            return true;
+        }
+
+        for (String beforeLabelName : beforeLabelNames) {
+            if (!newLabelNames.contains(beforeLabelName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void updateAll(Labels newLabels, ListEntity list) {
+        removeDeletedLabels(newLabels);
+        addNewLabels(newLabels, list);
+    }
+
+    private void removeDeletedLabels(Labels newLabels) {
+        Set<Label> beforeLabels = new HashSet<>(this.values);
+        newLabels.values.forEach(beforeLabels::remove);
+        this.values.removeAll(beforeLabels);
+    }
+
+    private void addNewLabels(Labels newLabels, ListEntity list) {
+        Set<Label> newLabelsSet = new HashSet<>(newLabels.values);
+        this.values.forEach(newLabelsSet::remove);
+        newLabelsSet.forEach(newLabel -> newLabel.updateList(list));
+        this.values.addAll(newLabelsSet);
     }
 
     public List<Label> getValues() {

--- a/src/main/java/com/listywave/list/application/domain/label/Labels.java
+++ b/src/main/java/com/listywave/list/application/domain/label/Labels.java
@@ -2,7 +2,7 @@ package com.listywave.list.application.domain.label;
 
 import static com.listywave.common.exception.ErrorCode.INVALID_COUNT;
 import static jakarta.persistence.CascadeType.ALL;
-import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.FetchType.EAGER;
 import static java.util.stream.Collectors.toSet;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -22,7 +22,7 @@ public class Labels {
 
     private static final int MAX_SIZE = 3;
 
-    @OneToMany(fetch = LAZY, mappedBy = "list", cascade = ALL, orphanRemoval = true)
+    @OneToMany(fetch = EAGER, mappedBy = "list", cascade = ALL, orphanRemoval = true)
     private final List<Label> values;
 
     public Labels(List<Label> labels) {

--- a/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
+++ b/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
@@ -1,6 +1,7 @@
 package com.listywave.list.application.domain.list;
 
 import static com.listywave.common.exception.ErrorCode.INVALID_ACCESS;
+import static com.listywave.common.exception.ErrorCode.RESOURCE_NOT_FOUND;
 import static com.listywave.list.application.domain.category.CategoryType.ENTIRE;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -10,6 +11,7 @@ import static lombok.AccessLevel.PROTECTED;
 import com.listywave.common.exception.CustomException;
 import com.listywave.list.application.domain.category.CategoryType;
 import com.listywave.list.application.domain.category.CategoryTypeConverter;
+import com.listywave.list.application.domain.item.Item;
 import com.listywave.list.application.domain.item.Items;
 import com.listywave.list.application.domain.label.Labels;
 import com.listywave.user.application.domain.User;
@@ -118,6 +120,12 @@ public class ListEntity {
         return items.getFirstImageUrl();
     }
 
+    public void validateOwner(User user) {
+        if (!this.user.equals(user)) {
+            throw new CustomException(INVALID_ACCESS);
+        }
+    }
+
     public boolean canDeleteOrUpdateBy(User user) {
         return this.user.equals(user);
     }
@@ -185,6 +193,12 @@ public class ListEntity {
         }
         if (this.items.isChange(newItems)) {
             this.items.updateAll(newItems, this);
+        }
+    }
+
+    public void validateHasItem(Item item) {
+        if (!this.items.contains(item)) {
+            throw new CustomException(RESOURCE_NOT_FOUND);
         }
     }
 }

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -8,6 +8,9 @@ import com.listywave.collaborator.application.domain.Collaborator;
 import com.listywave.collaborator.application.domain.Collaborators;
 import com.listywave.collaborator.repository.CollaboratorRepository;
 import com.listywave.common.exception.CustomException;
+import com.listywave.history.application.domain.History;
+import com.listywave.history.application.domain.HistoryItem;
+import com.listywave.history.repository.HistoryRepository;
 import com.listywave.image.application.service.ImageService;
 import com.listywave.list.application.domain.category.CategoryType;
 import com.listywave.list.application.domain.comment.Comment;
@@ -30,7 +33,9 @@ import com.listywave.list.application.dto.response.ListDetailResponse;
 import com.listywave.list.application.dto.response.ListRecentResponse;
 import com.listywave.list.application.dto.response.ListSearchResponse;
 import com.listywave.list.application.dto.response.ListTrandingResponse;
+import com.listywave.list.presentation.dto.request.ItemCreateRequest;
 import com.listywave.list.presentation.dto.request.ListCreateRequest;
+import com.listywave.list.presentation.dto.request.ListUpdateRequest;
 import com.listywave.list.repository.CommentRepository;
 import com.listywave.list.repository.list.ListRepository;
 import com.listywave.list.repository.reply.ReplyRepository;
@@ -38,6 +43,7 @@ import com.listywave.user.application.domain.Follow;
 import com.listywave.user.application.domain.User;
 import com.listywave.user.repository.follow.FollowRepository;
 import com.listywave.user.repository.user.UserRepository;
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -55,9 +61,10 @@ public class ListService {
     private final ListRepository listRepository;
     private final UserRepository userRepository;
     private final ReplyRepository replyRepository;
-    private final CommentRepository commentRepository;
-    private final CollaboratorRepository collaboratorRepository;
     private final FollowRepository followRepository;
+    private final CommentRepository commentRepository;
+    private final HistoryRepository historyRepository;
+    private final CollaboratorRepository collaboratorRepository;
 
     public ListCreateResponse listCreate(ListCreateRequest request, String accessToken) {
         Long userId = jwtManager.read(accessToken);
@@ -67,8 +74,8 @@ public class ListService {
         validateDuplicateCollaboratorIds(collaboratorIds);
         boolean hasCollaboration = !collaboratorIds.isEmpty();
 
-        Labels labels = createLabels(request);
-        Items items = createItems(request);
+        Labels labels = createLabels(request.labels());
+        Items items = createItems(request.items());
 
         ListEntity list = new ListEntity(user, request.category(), new ListTitle(request.title()),
                 new ListDescription(request.description()), request.isPublic(),
@@ -91,19 +98,19 @@ public class ListService {
         }
     }
 
-    private Labels createLabels(ListCreateRequest request) {
-        return new Labels(request.labels().stream()
+    private Labels createLabels(List<String> labels) {
+        return new Labels(labels.stream()
                 .map(LabelName::new)
                 .map(Label::init)
                 .toList());
     }
 
-    private Items createItems(ListCreateRequest request) {
-        return new Items(request.items().stream()
+    private Items createItems(List<ItemCreateRequest> itemCreateRequests) {
+        return new Items(itemCreateRequests.stream()
                 .map(it -> Item.init(
                         it.rank(),
                         new ItemTitle(it.title()), new ItemComment(it.comment()),
-                        new ItemLink(it.comment()), new ItemImageUrl(it.imageUrl()))
+                        new ItemLink(it.link()), new ItemImageUrl(it.imageUrl()))
                 ).toList());
     }
 
@@ -139,7 +146,7 @@ public class ListService {
         Long loginUserId = jwtManager.read(accessToken);
         User loginUser = userRepository.getById(loginUserId);
 
-        if (!list.canDeleteBy(loginUser)) {
+        if (!list.canDeleteOrUpdateBy(loginUser)) {
             throw new CustomException(INVALID_ACCESS, "리스트는 작성자만 삭제 가능합니다.");
         }
 
@@ -189,5 +196,32 @@ public class ListService {
             return ListSearchResponse.of(paged, totalCount, null, false);
         }
         return ListSearchResponse.of(paged, totalCount, paged.get(paged.size() - 1).getId(), false);
+    }
+
+    public void update(Long listId, String accessToken, ListUpdateRequest request) {
+        Long userId = jwtManager.read(accessToken);
+        User user = userRepository.getById(userId);
+        ListEntity list = listRepository.getById(listId);
+
+        List<Long> collaboratorIds = request.collaboratorIds();
+        validateDuplicateCollaboratorIds(collaboratorIds);
+        boolean hasCollaborator = !collaboratorIds.isEmpty();
+
+        Labels labels = createLabels(request.labels());
+        Items newItems = createItems(request.items());
+
+        LocalDateTime updatedDate = LocalDateTime.now();
+        if (list.canCreateHistory(newItems)) {
+            Items beforeItems = list.getItems();
+            List<HistoryItem> historyItems = beforeItems.toHistoryItems();
+            History history = new History(list, historyItems, updatedDate, request.isPublic());
+            historyRepository.save(history);
+        }
+        list.update(user, request.category(), new ListTitle(request.title()), new ListDescription(request.description()), request.isPublic(), request.backgroundColor(), hasCollaborator, updatedDate, labels, newItems);
+
+        if (hasCollaborator) {
+            Collaborators collaborators = createCollaborators(collaboratorIds, list);
+            collaboratorRepository.saveAll(collaborators.getCollaborators());
+        }
     }
 }

--- a/src/main/java/com/listywave/list/presentation/controller/ListController.java
+++ b/src/main/java/com/listywave/list/presentation/controller/ListController.java
@@ -11,12 +11,14 @@ import com.listywave.list.application.dto.response.ListSearchResponse;
 import com.listywave.list.application.dto.response.ListTrandingResponse;
 import com.listywave.list.application.service.ListService;
 import com.listywave.list.presentation.dto.request.ListCreateRequest;
+import com.listywave.list.presentation.dto.request.ListUpdateRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -81,5 +83,15 @@ public class ListController {
     ) {
         ListSearchResponse response = listService.search(keyword, sort, category, size, cursorId);
         return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/lists/{listId}")
+    ResponseEntity<Void> update(
+            @PathVariable("listId") Long listId,
+            @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken,
+            @RequestBody ListUpdateRequest request
+    ) {
+        listService.update(listId, accessToken, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/listywave/list/presentation/dto/request/ListUpdateRequest.java
+++ b/src/main/java/com/listywave/list/presentation/dto/request/ListUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.listywave.list.presentation.dto.request;
+
+import com.listywave.list.application.domain.category.CategoryType;
+import java.util.List;
+
+public record ListUpdateRequest(
+        CategoryType category,
+        List<String> labels,
+        List<Long> collaboratorIds,
+        String title,
+        String description,
+        boolean isPublic,
+        String backgroundColor,
+        List<ItemCreateRequest> items
+) {
+}

--- a/src/test/java/com/listywave/list/application/domain/item/ItemsTest.java
+++ b/src/test/java/com/listywave/list/application/domain/item/ItemsTest.java
@@ -1,0 +1,106 @@
+package com.listywave.list.application.domain.item;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ItemsTest {
+
+    @Test
+    void 아이템_순위에_변동사항이_없으면_히스토리를_생성할_수_없다() {
+        // given
+        Items items = new Items(List.of(
+                Item.init(1, new ItemTitle("신라면"), new ItemComment("사나이 울리는 신라면"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(2, new ItemTitle("진매"), new ItemComment("진매 은근 맛있음"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(3, new ItemTitle("간짬뽕"), new ItemComment("대학 시절 먹었던 간짬뽕은 1위"), new ItemLink(""), new ItemImageUrl(""))
+        ));
+
+        Items newItems = new Items(List.of(
+                Item.init(1, new ItemTitle("신라면"), new ItemComment("사나이 울리는 신라면"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(2, new ItemTitle("진매"), new ItemComment("진매 은근 맛있음"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(3, new ItemTitle("간짬뽕"), new ItemComment("대학 시절 먹었던 간짬뽕은 1위"), new ItemLink(""), new ItemImageUrl(""))
+        ));
+
+        // then
+        assertThat(items.canCreateHistory(newItems)).isFalse();
+    }
+
+    @Test
+    void 아이템이_새롭게_변경되면_히스토리를_생성할_수_있다() {
+        // given
+        Items items = new Items(List.of(
+                Item.init(1, new ItemTitle("신라면"), new ItemComment("사나이 울리는 신라면"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(2, new ItemTitle("진매"), new ItemComment("진매 은근 맛있음"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(3, new ItemTitle("간짬뽕"), new ItemComment("대학 시절 먹었던 간짬뽕은 1위"), new ItemLink(""), new ItemImageUrl(""))
+        ));
+
+        Items newItems = new Items(List.of(
+                Item.init(1, new ItemTitle("육개장 사발면"), new ItemComment("진리 아님?"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(2, new ItemTitle("김치 사발면"), new ItemComment("용호상박"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(3, new ItemTitle("신라면"), new ItemComment("신라면은 그래도 빠지지 않지"), new ItemLink(""), new ItemImageUrl(""))
+        ));
+
+        // then
+        assertThat(items.canCreateHistory(newItems)).isTrue();
+    }
+
+    @Test
+    void 아이템이_추가되면_히스토리를_생성할_수_있다() {
+        // given
+        Items items = new Items(List.of(
+                Item.init(1, new ItemTitle("신라면"), new ItemComment("사나이 울리는 신라면"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(2, new ItemTitle("진매"), new ItemComment("진매 은근 맛있음"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(3, new ItemTitle("간짬뽕"), new ItemComment("대학 시절 먹었던 간짬뽕은 1위"), new ItemLink(""), new ItemImageUrl(""))
+        ));
+
+        Items newItems = new Items(List.of(
+                Item.init(1, new ItemTitle("신라면"), new ItemComment("사나이 울리는 신라면"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(2, new ItemTitle("진매"), new ItemComment("진매 은근 맛있음"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(3, new ItemTitle("간짬뽕"), new ItemComment("대학 시절 먹었던 간짬뽕은 1위"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(4, new ItemTitle("참깨라면"), new ItemComment("피시방 전용 라면"), new ItemLink(""), new ItemImageUrl(""))
+        ));
+
+        // then
+        assertThat(items.canCreateHistory(newItems)).isTrue();
+    }
+
+    @Test
+    void 아이템이_삭제되면_히스토리를_생성할_수_있다() {
+        // given
+        Items beforeItems = new Items(List.of(
+                Item.init(1, new ItemTitle("신라면"), new ItemComment("사나이 울리는 신라면"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(2, new ItemTitle("진매"), new ItemComment("진매 은근 맛있음"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(3, new ItemTitle("간짬뽕"), new ItemComment("대학 시절 먹었던 간짬뽕은 1위"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(4, new ItemTitle("참깨라면"), new ItemComment("피시방 전용 라면"), new ItemLink(""), new ItemImageUrl(""))
+        ));
+
+        Items newItems = new Items(List.of(
+                Item.init(1, new ItemTitle("신라면"), new ItemComment("사나이 울리는 신라면"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(2, new ItemTitle("진매"), new ItemComment("진매 은근 맛있음"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(3, new ItemTitle("간짬뽕"), new ItemComment("대학 시절 먹었던 간짬뽕은 1위"), new ItemLink(""), new ItemImageUrl(""))
+        ));
+
+        // then
+        assertThat(beforeItems.canCreateHistory(newItems)).isTrue();
+    }
+
+    @Test
+    void 아이템_순위에_변경이_생기면_히스토리를_생성할_수_있다() {
+        // given
+        Items items = new Items(List.of(
+                Item.init(1, new ItemTitle("신라면"), new ItemComment("사나이 울리는 신라면"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(2, new ItemTitle("진매"), new ItemComment("진매 은근 맛있음"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(3, new ItemTitle("간짬뽕"), new ItemComment("대학 시절 먹었던 간짬뽕은 1위"), new ItemLink(""), new ItemImageUrl(""))
+        ));
+
+        Items newItems = new Items(List.of(
+                Item.init(1, new ItemTitle("간짬뽕"), new ItemComment("간짬뽕이 1위 됐네요"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(2, new ItemTitle("신라면"), new ItemComment("신라면이 2위 됐네요"), new ItemLink(""), new ItemImageUrl("")),
+                Item.init(3, new ItemTitle("진매"), new ItemComment("진매는 3위해라"), new ItemLink(""), new ItemImageUrl(""))
+        ));
+
+        // then
+        assertThat(items.canCreateHistory(newItems)).isTrue();
+    }
+}


### PR DESCRIPTION
# Description
1. 리스트 수정 API 구현했습니다.
아이템에 변동이 생길 경우 히스토리 객체 생성 및 저장도 이루어집니다.

2. 리스트 아이템 이미지를 삭제하는 기능을 구현했습니다.
리스트를 수정할 때, 이미지를 수정한다는 것은 단순하게 생각해서 **이미지 삭제 -> 새로운 이미지 추가**의 단계가 일어날 것입니다.
따라서 **이미지 삭제 기능만 구현하고, 기존에 리스트 생성 시에 사용되는 이미지 등록 관련 API를 재사용**하는 방식으로 리스트 이미지 변경 기능을 구현하고자 했습니다.

# Relation Issues
- close #68 