### PR TITLE
feat: 팔로잉, 팔로워 목록 조회의 정렬 기준을 닉네임 사전순으로 변경

### DIFF
--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -123,7 +123,7 @@ public class UserService {
     public FollowersResponse getFollowers(Long userId, int size, int cursorId) {
         User followingUser = userRepository.getById(userId);
 
-        List<Follow> follows = followRepository.findAllFollowersBy(followingUser, size, cursorId);
+        List<Follow> follows = followRepository.findAllByFollowingUserOrderByFollowerUserNicknameDesc(followingUser, size, cursorId);
         List<User> followerUsers = follows.stream()
                 .map(Follow::getFollowerUser)
                 .toList();

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -1,5 +1,7 @@
 package com.listywave.user.application.service;
 
+import static java.util.Comparator.comparing;
+
 import com.listywave.auth.application.domain.JwtManager;
 import com.listywave.collaborator.application.domain.Collaborator;
 import com.listywave.collaborator.repository.CollaboratorRepository;
@@ -90,6 +92,7 @@ public class UserService {
 
         List<User> followingUsers = follows.stream()
                 .map(Follow::getFollowingUser)
+                .sorted(comparing(User::getNickname))
                 .toList();
         return FollowingsResponse.of(followingUsers);
     }
@@ -120,7 +123,7 @@ public class UserService {
     public FollowersResponse getFollowers(Long userId, int size, int cursorId) {
         User followingUser = userRepository.getById(userId);
 
-        List<Follow> follows = followRepository.findAllByFollowingUser(followingUser, size, cursorId);
+        List<Follow> follows = followRepository.findAllFollowersBy(followingUser, size, cursorId);
         List<User> followerUsers = follows.stream()
                 .map(Follow::getFollowerUser)
                 .toList();

--- a/src/main/java/com/listywave/user/repository/follow/custom/CustomFollowRepository.java
+++ b/src/main/java/com/listywave/user/repository/follow/custom/CustomFollowRepository.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public interface CustomFollowRepository {
 
-    List<Follow> findAllByFollowingUser(User user, int size, int cursorId);
+    List<Follow> findAllFollowersBy(User user, int size, int cursorId);
 }

--- a/src/main/java/com/listywave/user/repository/follow/custom/CustomFollowRepository.java
+++ b/src/main/java/com/listywave/user/repository/follow/custom/CustomFollowRepository.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public interface CustomFollowRepository {
 
-    List<Follow> findAllFollowersBy(User user, int size, int cursorId);
+    List<Follow> findAllByFollowingUserOrderByFollowerUserNicknameDesc(User user, int size, int cursorId);
 }

--- a/src/main/java/com/listywave/user/repository/follow/custom/impl/CustomFollowRepositoryImpl.java
+++ b/src/main/java/com/listywave/user/repository/follow/custom/impl/CustomFollowRepositoryImpl.java
@@ -15,7 +15,7 @@ public class CustomFollowRepositoryImpl implements CustomFollowRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Follow> findAllFollowersBy(User followingUser, int size, int cursorId) {
+    public List<Follow> findAllByFollowingUserOrderByFollowerUserNicknameDesc(User followingUser, int size, int cursorId) {
         return queryFactory.selectFrom(follow)
                 .where(
                         follow.followingUser.id.eq(followingUser.getId()),

--- a/src/main/java/com/listywave/user/repository/follow/custom/impl/CustomFollowRepositoryImpl.java
+++ b/src/main/java/com/listywave/user/repository/follow/custom/impl/CustomFollowRepositoryImpl.java
@@ -15,13 +15,13 @@ public class CustomFollowRepositoryImpl implements CustomFollowRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Follow> findAllByFollowingUser(User followingUser, int size, int cursorId) {
+    public List<Follow> findAllFollowersBy(User followingUser, int size, int cursorId) {
         return queryFactory.selectFrom(follow)
                 .where(
-                        follow.followingUser.eq(followingUser),
+                        follow.followingUser.id.eq(followingUser.getId()),
                         follow.followingUser.id.gt(cursorId)
                 )
-                .orderBy(follow.createdDate.desc())
+                .orderBy(follow.followerUser.nickname.value.asc())
                 .limit(size + 1)
                 .fetch();
     }


### PR DESCRIPTION
# Description
팔로잉, 팔로워 목록 조회 시에 **정렬 기준을 닉네임 사전순으로 변경**했습니다.
QueryDsl 짱!

# Relation Issues
- close #127 
