### PR TITLE
feat: 이벤트 구독 발행 방식의 Alarm 등록,  Alarm 리스트 조회, Alarm 읽기 API 구현

### DIFF
--- a/src/main/java/com/listywave/alarm/application/domain/Alarm.java
+++ b/src/main/java/com/listywave/alarm/application/domain/Alarm.java
@@ -1,0 +1,64 @@
+package com.listywave.alarm.application.domain;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static jakarta.persistence.TemporalType.TIMESTAMP;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.listywave.user.application.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Temporal;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Alarm {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "send_user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private Long receiveUserId;
+
+    private Long listId;
+    private Long commentId;
+
+    @Column(nullable = false)
+    @Enumerated(value = STRING)
+    private AlarmType type;
+
+    @Column(nullable = false)
+    private boolean isChecked = false;
+
+    @CreatedDate
+    @Temporal(TIMESTAMP)
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    public void alarmRead() {
+        this.isChecked = true;
+    }
+}

--- a/src/main/java/com/listywave/alarm/application/domain/Alarm.java
+++ b/src/main/java/com/listywave/alarm/application/domain/Alarm.java
@@ -43,7 +43,10 @@ public class Alarm {
     @Column(nullable = false)
     private Long receiveUserId;
 
+    @Column(nullable = true)
     private Long listId;
+
+    @Column(nullable = true)
     private Long commentId;
 
     @Column(nullable = false)
@@ -58,7 +61,7 @@ public class Alarm {
     @Column(updatable = false)
     private LocalDateTime createdDate;
 
-    public void alarmRead() {
+    public void readAlarm() {
         this.isChecked = true;
     }
 }

--- a/src/main/java/com/listywave/alarm/application/domain/AlarmEvent.java
+++ b/src/main/java/com/listywave/alarm/application/domain/AlarmEvent.java
@@ -1,0 +1,71 @@
+package com.listywave.alarm.application.domain;
+
+import com.listywave.list.application.domain.comment.Comment;
+import com.listywave.list.application.domain.list.ListEntity;
+import com.listywave.list.application.domain.reply.Reply;
+import com.listywave.user.application.domain.User;
+import lombok.Builder;
+
+@Builder
+public record AlarmEvent(
+        User publisher,
+        Long listenerId,
+        Long listId,
+        Long commentId,
+        AlarmType alarmType
+) {
+
+    public Alarm toEntity() {
+        return Alarm.builder()
+                .user(publisher)
+                .receiveUserId(listenerId)
+                .listId(listId)
+                .commentId(commentId)
+                .type(alarmType)
+                .build();
+    }
+
+    public static AlarmEvent followOf(User publisher, User listenerUser) {
+        return AlarmEvent.builder()
+                .publisher(publisher)
+                .listenerId(listenerUser.getId())
+                .listId(null)
+                .commentId(null)
+                .alarmType(AlarmType.FOLLOW)
+                .build();
+    }
+
+    public static AlarmEvent collectOf(User publisher, ListEntity list) {
+        return AlarmEvent.builder()
+                .publisher(publisher)
+                .listenerId(list.getUser().getId())
+                .listId(list.getId())
+                .commentId(null)
+                .alarmType(AlarmType.COLLECT)
+                .build();
+    }
+
+    public static AlarmEvent commentOf(ListEntity list, Comment comment) {
+        return AlarmEvent.builder()
+                .publisher(comment.getUser())
+                .listenerId(list.getUser().getId())
+                .listId(list.getId())
+                .commentId(comment.getId())
+                .alarmType(AlarmType.COMMENT)
+                .build();
+    }
+
+    public static AlarmEvent replyOf(Comment comment, Reply reply) {
+        return AlarmEvent.builder()
+                .publisher(reply.getUser())
+                .listenerId(comment.getUser().getId())
+                .listId(comment.getList().getId())
+                .commentId(comment.getId())
+                .alarmType(AlarmType.REPLY)
+                .build();
+    }
+
+    public boolean isDifferentPublisher() {
+        return !publisher.isSame(listenerId);
+    }
+}

--- a/src/main/java/com/listywave/alarm/application/domain/AlarmEvent.java
+++ b/src/main/java/com/listywave/alarm/application/domain/AlarmEvent.java
@@ -1,5 +1,12 @@
 package com.listywave.alarm.application.domain;
 
+import static com.listywave.alarm.application.domain.AlarmType.COLLECT;
+import static com.listywave.alarm.application.domain.AlarmType.COMMENT;
+import static com.listywave.alarm.application.domain.AlarmType.FOLLOW;
+import static com.listywave.alarm.application.domain.AlarmType.REPLY;
+
+import com.listywave.common.exception.CustomException;
+import com.listywave.common.exception.ErrorCode;
 import com.listywave.list.application.domain.comment.Comment;
 import com.listywave.list.application.domain.list.ListEntity;
 import com.listywave.list.application.domain.reply.Reply;
@@ -25,47 +32,49 @@ public record AlarmEvent(
                 .build();
     }
 
-    public static AlarmEvent followOf(User publisher, User listenerUser) {
+    public static AlarmEvent follow(User publisher, User listenerUser) {
         return AlarmEvent.builder()
                 .publisher(publisher)
                 .listenerId(listenerUser.getId())
                 .listId(null)
                 .commentId(null)
-                .alarmType(AlarmType.FOLLOW)
+                .alarmType(FOLLOW)
                 .build();
     }
 
-    public static AlarmEvent collectOf(User publisher, ListEntity list) {
+    public static AlarmEvent collect(User publisher, ListEntity list) {
         return AlarmEvent.builder()
                 .publisher(publisher)
                 .listenerId(list.getUser().getId())
                 .listId(list.getId())
                 .commentId(null)
-                .alarmType(AlarmType.COLLECT)
+                .alarmType(COLLECT)
                 .build();
     }
 
-    public static AlarmEvent commentOf(ListEntity list, Comment comment) {
+    public static AlarmEvent comment(ListEntity list, Comment comment) {
         return AlarmEvent.builder()
                 .publisher(comment.getUser())
                 .listenerId(list.getUser().getId())
                 .listId(list.getId())
                 .commentId(comment.getId())
-                .alarmType(AlarmType.COMMENT)
+                .alarmType(COMMENT)
                 .build();
     }
 
-    public static AlarmEvent replyOf(Comment comment, Reply reply) {
+    public static AlarmEvent reply(Comment comment, Reply reply) {
         return AlarmEvent.builder()
                 .publisher(reply.getUser())
                 .listenerId(comment.getUser().getId())
                 .listId(comment.getList().getId())
                 .commentId(comment.getId())
-                .alarmType(AlarmType.REPLY)
+                .alarmType(REPLY)
                 .build();
     }
 
-    public boolean isDifferentPublisher() {
-        return !publisher.isSame(listenerId);
+    public void validateDifferentPublisherAndReceiver() {
+        if (publisher.isSame(listenerId)) {
+            throw new CustomException(ErrorCode.CANNOT_SEND_OWN_ALARM);
+        }
     }
 }

--- a/src/main/java/com/listywave/alarm/application/domain/AlarmType.java
+++ b/src/main/java/com/listywave/alarm/application/domain/AlarmType.java
@@ -1,0 +1,15 @@
+package com.listywave.alarm.application.domain;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum AlarmType {
+
+    FOLLOW("follow"),
+    COLLECT("collect"),
+    COMMENT("comment"),
+    REPLY("reply"),
+    ;
+
+    private final String value;
+}

--- a/src/main/java/com/listywave/alarm/application/dto/AlarmListResponse.java
+++ b/src/main/java/com/listywave/alarm/application/dto/AlarmListResponse.java
@@ -3,8 +3,4 @@ package com.listywave.alarm.application.dto;
 import java.util.List;
 
 public record AlarmListResponse(List<AlarmResponse> alarmList) {
-
-    public static AlarmListResponse of(List<AlarmResponse> alarmList) {
-        return new AlarmListResponse(alarmList);
-    }
 }

--- a/src/main/java/com/listywave/alarm/application/dto/AlarmListResponse.java
+++ b/src/main/java/com/listywave/alarm/application/dto/AlarmListResponse.java
@@ -1,0 +1,10 @@
+package com.listywave.alarm.application.dto;
+
+import java.util.List;
+
+public record AlarmListResponse(List<AlarmResponse> alarmList) {
+
+    public static AlarmListResponse of(List<AlarmResponse> alarmList) {
+        return new AlarmListResponse(alarmList);
+    }
+}

--- a/src/main/java/com/listywave/alarm/application/dto/AlarmResponse.java
+++ b/src/main/java/com/listywave/alarm/application/dto/AlarmResponse.java
@@ -1,0 +1,21 @@
+package com.listywave.alarm.application.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AlarmResponse {
+
+    private Long id;
+    private Long sendUserId;
+    private String nickname;
+    private String profileImageUrl;
+    private Long listId;
+    private Long commentId;
+    private String listTitle;
+    private String type;
+    private boolean isChecked;
+    private LocalDateTime createdDate;
+}

--- a/src/main/java/com/listywave/alarm/application/handler/AlarmEventHandler.java
+++ b/src/main/java/com/listywave/alarm/application/handler/AlarmEventHandler.java
@@ -1,0 +1,19 @@
+package com.listywave.alarm.application.handler;
+
+import com.listywave.alarm.application.domain.AlarmEvent;
+import com.listywave.alarm.application.service.AlarmService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class AlarmEventHandler {
+
+    private final AlarmService alarmService;
+
+    @TransactionalEventListener
+    public void saveAlarm(AlarmEvent alarmEvent) {
+        alarmService.save(alarmEvent);
+    }
+}

--- a/src/main/java/com/listywave/alarm/application/service/AlarmService.java
+++ b/src/main/java/com/listywave/alarm/application/service/AlarmService.java
@@ -1,0 +1,47 @@
+package com.listywave.alarm.application.service;
+
+import static com.listywave.common.exception.ErrorCode.RESOURCE_NOT_FOUND;
+
+import com.listywave.alarm.application.domain.AlarmEvent;
+import com.listywave.alarm.application.dto.AlarmListResponse;
+import com.listywave.alarm.repository.AlarmRepository;
+import com.listywave.auth.application.domain.JwtManager;
+import com.listywave.common.exception.CustomException;
+import com.listywave.user.application.domain.User;
+import com.listywave.user.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AlarmService {
+
+    private final JwtManager jwtManager;
+    private final AlarmRepository alarmRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public AlarmListResponse getAlarms(String accessToken) {
+        Long tokenUserId = jwtManager.read(accessToken);
+        User user = userRepository.getById(tokenUserId);
+        return AlarmListResponse.of(alarmRepository.getAlarms(user));
+    }
+
+    public void alarmRead(Long alarmId, String accessToken) {
+        Long tokenUserId = jwtManager.read(accessToken);
+        User user = userRepository.getById(tokenUserId);
+        alarmRepository.findAlarmByIdAndReceiveUserId(alarmId, user.getId())
+                .orElseThrow(() -> new CustomException(RESOURCE_NOT_FOUND))
+                .alarmRead();
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void save(AlarmEvent alarmEvent) {
+        if (alarmEvent.isDifferentPublisher()) {
+            alarmRepository.save(alarmEvent.toEntity());
+        }
+    }
+}

--- a/src/main/java/com/listywave/alarm/presentation/controller/AlarmController.java
+++ b/src/main/java/com/listywave/alarm/presentation/controller/AlarmController.java
@@ -26,11 +26,11 @@ public class AlarmController {
     }
 
     @PatchMapping("/alarms/{alarmId}")
-    ResponseEntity<AlarmListResponse> alarmRead(
+    ResponseEntity<AlarmListResponse> readAlarm(
             @PathVariable("alarmId") Long alarmId,
             @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken
     ) {
-        alarmService.alarmRead(alarmId, accessToken);
+        alarmService.readAlarm(alarmId, accessToken);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/listywave/alarm/presentation/controller/AlarmController.java
+++ b/src/main/java/com/listywave/alarm/presentation/controller/AlarmController.java
@@ -1,0 +1,36 @@
+package com.listywave.alarm.presentation.controller;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import com.listywave.alarm.application.dto.AlarmListResponse;
+import com.listywave.alarm.application.service.AlarmService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AlarmController {
+
+    private final AlarmService alarmService;
+
+    @GetMapping("/alarms")
+    ResponseEntity<AlarmListResponse> getAlarms(
+            @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken
+    ) {
+        return ResponseEntity.ok(alarmService.getAlarms(accessToken));
+    }
+
+    @PatchMapping("/alarms/{alarmId}")
+    ResponseEntity<AlarmListResponse> alarmRead(
+            @PathVariable("alarmId") Long alarmId,
+            @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken
+    ) {
+        alarmService.alarmRead(alarmId, accessToken);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/listywave/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/listywave/alarm/repository/AlarmRepository.java
@@ -1,0 +1,11 @@
+package com.listywave.alarm.repository;
+
+import com.listywave.alarm.application.domain.Alarm;
+import com.listywave.alarm.repository.custom.CustomAlarmRepository;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlarmRepository extends JpaRepository<Alarm, Long>, CustomAlarmRepository {
+
+    Optional<Alarm> findAlarmByIdAndReceiveUserId(Long id, Long receiveUserId);
+}

--- a/src/main/java/com/listywave/alarm/repository/custom/CustomAlarmRepository.java
+++ b/src/main/java/com/listywave/alarm/repository/custom/CustomAlarmRepository.java
@@ -1,0 +1,11 @@
+package com.listywave.alarm.repository.custom;
+
+import com.listywave.alarm.application.dto.AlarmResponse;
+import com.listywave.user.application.domain.User;
+import java.util.List;
+
+public interface CustomAlarmRepository {
+    List<AlarmResponse> getAlarms(User user);
+
+    void deleteAlarmThirtyDaysAgo();
+}

--- a/src/main/java/com/listywave/alarm/repository/custom/impl/CustomAlarmRepositoryImpl.java
+++ b/src/main/java/com/listywave/alarm/repository/custom/impl/CustomAlarmRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.listywave.alarm.repository.custom.impl;
+
+import static com.listywave.alarm.application.domain.QAlarm.alarm;
+import static com.listywave.list.application.domain.list.QListEntity.listEntity;
+
+import com.listywave.alarm.application.dto.AlarmResponse;
+import com.listywave.alarm.repository.custom.CustomAlarmRepository;
+import com.listywave.user.application.domain.User;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomAlarmRepositoryImpl implements CustomAlarmRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<AlarmResponse> getAlarms(User user) {
+        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+
+        return queryFactory
+                .select(Projections.fields(AlarmResponse.class,
+                        alarm.id,
+                        alarm.user.id.as("sendUserId"),
+                        alarm.user.nickname.value.as("nickname"),
+                        alarm.user.profileImageUrl.value.as("profileImageUrl"),
+                        alarm.listId,
+                        alarm.commentId,
+                        listEntity.title.value.as("listTitle"),
+                        alarm.type.stringValue().as("type"),
+                        alarm.isChecked,
+                        alarm.createdDate
+                ))
+                .from(alarm)
+                .leftJoin(listEntity).on(alarm.listId.eq(listEntity.id))
+                .where(
+                        alarm.receiveUserId.eq(user.getId()),
+                        alarm.createdDate.goe(thirtyDaysAgo)
+                )
+                .orderBy(alarm.id.desc())
+                .fetch();
+    }
+
+    @Override
+    public void deleteAlarmThirtyDaysAgo() {
+        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+
+        queryFactory.delete(alarm)
+                .where(alarm.createdDate.loe(thirtyDaysAgo))
+                .execute();
+    }
+}

--- a/src/main/java/com/listywave/collaborator/application/dto/CollaboratorSearchResponse.java
+++ b/src/main/java/com/listywave/collaborator/application/dto/CollaboratorSearchResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 
 @Builder
 public record CollaboratorSearchResponse(
-        List<CollaboratorResponse> collaborators,
+        List<CollaboratorResponse> users,
         Long totalCount,
         Boolean hasNext
 ) {
@@ -16,7 +16,7 @@ public record CollaboratorSearchResponse(
             Boolean hasNext
     ) {
         return CollaboratorSearchResponse.builder()
-                .collaborators(users)
+                .users(users)
                 .totalCount(totalCount)
                 .hasNext(hasNext)
                 .build();

--- a/src/main/java/com/listywave/collection/application/service/CollectionService.java
+++ b/src/main/java/com/listywave/collection/application/service/CollectionService.java
@@ -47,7 +47,7 @@ public class CollectionService {
         collectionRepository.save(collection);
         list.incrementCollectCount();
 
-        applicationEventPublisher.publishEvent(AlarmEvent.collectOf(user, list));
+        applicationEventPublisher.publishEvent(AlarmEvent.collect(user, list));
     }
 
     private void cancelCollect(ListEntity list, Long userId) {

--- a/src/main/java/com/listywave/common/exception/ErrorCode.java
+++ b/src/main/java/com/listywave/common/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     INVALID_ACCESS_TOKEN(UNAUTHORIZED, "유효하지 않은 AccessToken 입니다. 다시 로그인해주세요."),
     INVALID_ACCESS(FORBIDDEN, "접근 권한이 존재하지 않습니다."),
     CANNOT_COLLECT_OWN_LIST(BAD_REQUEST, "리스트 작성자는 자신의 리스트에 콜렉트할 수 없습니다."),
+    CANNOT_SEND_OWN_ALARM(BAD_REQUEST, "알람을 자신에게 보낼 수 없습니다."),
 
     // Http Request
     METHOD_ARGUMENT_TYPE_MISMATCH(BAD_REQUEST, "요청 한 값 타입이 잘못되어 binding에 실패하였습니다."),

--- a/src/main/java/com/listywave/image/application/service/ImageService.java
+++ b/src/main/java/com/listywave/image/application/service/ImageService.java
@@ -106,12 +106,11 @@ public class ImageService {
     }
 
     public UserPresignedUrlResponse updateUserImagePresignedUrl(
-            Long ownerId,
             ImageFileExtension profileExtension,
             ImageFileExtension backgroundExtension,
             String accessToken
     ) {
-        jwtManager.read(accessToken);
+        Long ownerId = jwtManager.read(accessToken);
         User user = userRepository.getById(ownerId);
 
         if (isExistProfileExtension(profileExtension, backgroundExtension)) {
@@ -152,10 +151,11 @@ public class ImageService {
     }
 
     public void uploadCompleteUserImages(
-            Long ownerId,
             ImageFileExtension profileExtension,
-            ImageFileExtension backgroundExtension
+            ImageFileExtension backgroundExtension,
+            String accessToken
     ) {
+        Long ownerId = jwtManager.read(accessToken);
         User user = userRepository.getById(ownerId);
 
         String profileImageUrl = "";

--- a/src/main/java/com/listywave/image/presentation/controller/ImageController.java
+++ b/src/main/java/com/listywave/image/presentation/controller/ImageController.java
@@ -45,7 +45,6 @@ public class ImageController {
             @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken
     ) {
         UserPresignedUrlResponse userPresignedUrlResponse = imageService.updateUserImagePresignedUrl(
-                request.ownerId(),
                 request.profileExtension(),
                 request.backgroundExtension(),
                 accessToken
@@ -55,12 +54,13 @@ public class ImageController {
 
     @PostMapping("/users/upload-complete")
     ResponseEntity<Void> userImageUpload(
-            @RequestBody UserImageUpdateRequest request
+            @RequestBody UserImageUpdateRequest request,
+            @RequestHeader(value = AUTHORIZATION, defaultValue = "") String accessToken
     ) {
         imageService.uploadCompleteUserImages(
-                request.ownerId(),
                 request.profileExtension(),
-                request.backgroundExtension()
+                request.backgroundExtension(),
+                accessToken
         );
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/listywave/image/presentation/dto/request/UserImageUpdateRequest.java
+++ b/src/main/java/com/listywave/image/presentation/dto/request/UserImageUpdateRequest.java
@@ -3,7 +3,6 @@ package com.listywave.image.presentation.dto.request;
 import com.listywave.image.application.domain.ImageFileExtension;
 
 public record UserImageUpdateRequest(
-        Long ownerId,
         ImageFileExtension profileExtension,
         ImageFileExtension backgroundExtension
 ) {

--- a/src/main/java/com/listywave/list/application/service/CommentService.java
+++ b/src/main/java/com/listywave/list/application/service/CommentService.java
@@ -4,6 +4,7 @@ import static com.listywave.common.exception.ErrorCode.INVALID_ACCESS;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
+import com.listywave.alarm.application.domain.AlarmEvent;
 import com.listywave.auth.application.domain.JwtManager;
 import com.listywave.common.exception.CustomException;
 import com.listywave.list.application.domain.comment.Comment;
@@ -22,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -34,6 +36,7 @@ public class CommentService {
     private final UserRepository userRepository;
     private final ReplyRepository replyRepository;
     private final CommentRepository commentRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public CommentCreateResponse create(Long listId, String content, String accessToken) {
         Long userId = jwtManager.read(accessToken);
@@ -43,6 +46,7 @@ public class CommentService {
         Comment comment = Comment.create(list, user, new CommentContent(content));
         Comment saved = commentRepository.save(comment);
 
+        applicationEventPublisher.publishEvent(AlarmEvent.commentOf(list, saved));
         return CommentCreateResponse.of(saved, user);
     }
 

--- a/src/main/java/com/listywave/list/application/service/CommentService.java
+++ b/src/main/java/com/listywave/list/application/service/CommentService.java
@@ -46,7 +46,7 @@ public class CommentService {
         Comment comment = Comment.create(list, user, new CommentContent(content));
         Comment saved = commentRepository.save(comment);
 
-        applicationEventPublisher.publishEvent(AlarmEvent.commentOf(list, saved));
+        applicationEventPublisher.publishEvent(AlarmEvent.comment(list, saved));
         return CommentCreateResponse.of(saved, user);
     }
 

--- a/src/main/java/com/listywave/list/application/service/ReplyService.java
+++ b/src/main/java/com/listywave/list/application/service/ReplyService.java
@@ -40,7 +40,7 @@ public class ReplyService {
         Reply reply = new Reply(comment, user, new CommentContent(content));
         Reply saved = replyRepository.save(reply);
 
-        applicationEventPublisher.publishEvent(AlarmEvent.replyOf(comment, saved));
+        applicationEventPublisher.publishEvent(AlarmEvent.reply(comment, saved));
         return ReplyCreateResponse.of(saved, comment, user);
     }
 

--- a/src/main/java/com/listywave/list/application/service/ReplyService.java
+++ b/src/main/java/com/listywave/list/application/service/ReplyService.java
@@ -1,5 +1,6 @@
 package com.listywave.list.application.service;
 
+import com.listywave.alarm.application.domain.AlarmEvent;
 import com.listywave.auth.application.domain.JwtManager;
 import com.listywave.common.exception.CustomException;
 import com.listywave.common.exception.ErrorCode;
@@ -14,6 +15,7 @@ import com.listywave.list.repository.reply.ReplyRepository;
 import com.listywave.user.application.domain.User;
 import com.listywave.user.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +29,7 @@ public class ReplyService {
     private final UserRepository userRepository;
     private final ReplyRepository replyRepository;
     private final CommentRepository commentRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public ReplyCreateResponse createReply(Long listId, Long commentId, String content, String accessToken) {
         listRepository.getById(listId);
@@ -37,6 +40,7 @@ public class ReplyService {
         Reply reply = new Reply(comment, user, new CommentContent(content));
         Reply saved = replyRepository.save(reply);
 
+        applicationEventPublisher.publishEvent(AlarmEvent.replyOf(comment, saved));
         return ReplyCreateResponse.of(saved, comment, user);
     }
 

--- a/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.listywave.list.application.domain.list.ListEntity;
 import com.listywave.list.repository.list.custom.CustomListRepository;
 import com.listywave.user.application.domain.User;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
@@ -19,9 +20,12 @@ public class CustomListRepositoryImpl implements CustomListRepository {
 
     @Override
     public List<ListEntity> findTrandingLists() {
+        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+
         return queryFactory
                 .selectFrom(listEntity)
                 .leftJoin(item).on(listEntity.id.eq(item.list.id))
+                .where(listEntity.updatedDate.goe(thirtyDaysAgo))
                 .distinct()
                 .limit(10)
                 .orderBy(listEntity.collectCount.desc(), listEntity.viewCount.desc(), listEntity.id.desc())
@@ -30,11 +34,14 @@ public class CustomListRepositoryImpl implements CustomListRepository {
 
     @Override
     public List<ListEntity> getRecentLists() {
+        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+
         return queryFactory
                 .selectFrom(listEntity)
                 .join(listEntity.user, user).fetchJoin()
                 .leftJoin(label).on(listEntity.id.eq(label.list.id))
                 .leftJoin(item).on(listEntity.id.eq(item.list.id))
+                .where(listEntity.updatedDate.goe(thirtyDaysAgo))
                 .distinct()
                 .limit(10)
                 .orderBy(listEntity.updatedDate.desc())
@@ -43,6 +50,8 @@ public class CustomListRepositoryImpl implements CustomListRepository {
 
     @Override
     public List<ListEntity> getRecentListsByFollowing(List<User> followingUsers) {
+        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+
         List<Long> followingUserIds = followingUsers.stream()
                 .map(User::getId)
                 .toList();
@@ -52,7 +61,10 @@ public class CustomListRepositoryImpl implements CustomListRepository {
                 .join(listEntity.user, user).fetchJoin()
                 .leftJoin(label).on(listEntity.id.eq(label.list.id))
                 .leftJoin(item).on(listEntity.id.eq(item.list.id))
-                .where(listEntity.user.id.in(followingUserIds))
+                .where(
+                        listEntity.updatedDate.goe(thirtyDaysAgo),
+                        listEntity.user.id.in(followingUserIds)
+                )
                 .distinct()
                 .limit(10)
                 .orderBy(listEntity.updatedDate.desc())

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -161,9 +161,7 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public Boolean checkNicknameDuplicate(String nickname, String accessToken) {
-        Long loginUserId = jwtManager.read(accessToken);
-        userRepository.getById(loginUserId);
+    public Boolean checkNicknameDuplicate(String nickname) {
         return userRepository.existsByNicknameValue(nickname);
     }
 }

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -1,5 +1,6 @@
 package com.listywave.user.application.service;
 
+import com.listywave.alarm.application.domain.AlarmEvent;
 import com.listywave.auth.application.domain.JwtManager;
 import com.listywave.collaborator.application.domain.Collaborator;
 import com.listywave.collaborator.repository.CollaboratorRepository;
@@ -19,6 +20,7 @@ import com.listywave.user.repository.follow.FollowRepository;
 import com.listywave.user.repository.user.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +34,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final FollowRepository followRepository;
     private final CollaboratorRepository collaboratorRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional(readOnly = true)
     public UserInfoResponse getUserInfo(Long userId, String accessToken) {
@@ -104,6 +107,8 @@ public class UserService {
         followRepository.save(follow);
 
         followerUser.follow(followingUser);
+
+        applicationEventPublisher.publishEvent(AlarmEvent.followOf(followerUser, followingUser));
     }
 
     public void unfollow(Long followingUserId, String accessToken) {

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -108,7 +108,7 @@ public class UserService {
 
         followerUser.follow(followingUser);
 
-        applicationEventPublisher.publishEvent(AlarmEvent.followOf(followerUser, followingUser));
+        applicationEventPublisher.publishEvent(AlarmEvent.follow(followerUser, followingUser));
     }
 
     public void unfollow(Long followingUserId, String accessToken) {

--- a/src/main/java/com/listywave/user/presentation/UserController.java
+++ b/src/main/java/com/listywave/user/presentation/UserController.java
@@ -13,7 +13,6 @@ import com.listywave.user.application.service.UserService;
 import com.listywave.user.presentation.dto.UserProfileUpdateRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -111,9 +110,8 @@ public class UserController {
 
     @GetMapping("/users/exists")
     ResponseEntity<Boolean> checkNicknameDuplicate(
-            @RequestParam(name = "nickname") String nickname,
-            @RequestHeader(value = HttpHeaders.AUTHORIZATION, defaultValue = "") String accessToken
+            @RequestParam(name = "nickname") String nickname
     ) {
-        return ResponseEntity.ok(userService.checkNicknameDuplicate(nickname, accessToken));
+        return ResponseEntity.ok(userService.checkNicknameDuplicate(nickname));
     }
 }


### PR DESCRIPTION
# Description
### 🚨 dev에 merge 하기 전에 알람 테이블 생성 해야함!!

- **이벤트 구독 발행 방식의 Alarm 등록되도록 구현하였습니다.** 
-> 이벤트 구동 발행 방식으로 사용한 이유는 기존 로직에 결합도를 낮출 수 있고, 알림과 서로 의존하지 않기 위함이며 트랜젝션의 문제를 방지하기 위함이 있습니다.
ex) 댓글을 등록 완료 후 곧 바로 알림 추가하는 과정에서 예외가 발생해 성공적으로 수행된 댓글도 롤백이 되어버리는 문제가 발생하는 것을 방지! 

- **내 알람 리스트 조회 API를 구현하였습니다.**
  - 최근 30일 알람 모두 가져옴
  - type
      - 팔로우 : FOLLOW 
      - 콜렉트 : COLLECT 
      - 댓글 : COMMENT
      - 답글 : REPLY
- **알람 읽기 API를 구현하였습니다.** 
- **탐색 API 에서 최근 30일 기준으로 가져오도록 변경**
- batch, scheduler 이용한 30일 이전 알람은 자동 삭제 기능은 구현 중 잘 되지 않아 일단 추후 작업 예정입니다...ㅜ
# Reference
https://junuuu.tistory.com/726
# Relation Issues
- close #134 
- close #135
- close #133
- close #103 