### PR TITLE
feat: 팔로잉/팔로워 목록에서 닉네임으로 검색 하능하도록 구현 및 리펙토링

### DIFF
--- a/src/main/java/com/listywave/user/application/dto/FollowersResponse.java
+++ b/src/main/java/com/listywave/user/application/dto/FollowersResponse.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 public record FollowersResponse(
         List<FollowerInfo> followers,
         int totalCount,
-        Long cursorId,
+        String cursorId,
         boolean hasNext
 ) {
 
@@ -17,7 +17,7 @@ public record FollowersResponse(
         return FollowersResponse.builder()
                 .followers(FollowerInfo.toList(users))
                 .totalCount(totalCount)
-                .cursorId(users.get(users.size() - 1).getId())
+                .cursorId(users.get(users.size() - 1).getNickname())
                 .hasNext(hasNext)
                 .build();
     }

--- a/src/main/java/com/listywave/user/application/dto/FollowingsResponse.java
+++ b/src/main/java/com/listywave/user/application/dto/FollowingsResponse.java
@@ -34,4 +34,3 @@ record FollowingUserInfo(
                 .build();
     }
 }
-

--- a/src/main/java/com/listywave/user/presentation/UserController.java
+++ b/src/main/java/com/listywave/user/presentation/UserController.java
@@ -15,7 +15,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -62,18 +61,22 @@ public class UserController {
     }
 
     @GetMapping("/users/{userId}/followings")
-    ResponseEntity<FollowingsResponse> getFollowings(@PathVariable(name = "userId") Long userId) {
-        FollowingsResponse response = userService.getFollowings(userId);
+    ResponseEntity<FollowingsResponse> getFollowings(
+            @PathVariable(name = "userId") Long userId,
+            @RequestParam(name = "search", defaultValue = "") String search
+    ) {
+        FollowingsResponse response = userService.getFollowings(userId, search);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/users/{userId}/followers")
     ResponseEntity<FollowersResponse> getFollowers(
             @PathVariable(name = "userId") Long userId,
-            @RequestParam(name = "size", defaultValue = "20") int size,
-            @RequestParam(name = "cursorId", defaultValue = "0") int cursorId
+            @RequestParam(name = "cursorId", required = false) String cursorId,
+            @RequestParam(name = "search", defaultValue = "") String search,
+            @PageableDefault(size = 20) Pageable pageable
     ) {
-        FollowersResponse response = userService.getFollowers(userId, size, cursorId);
+        FollowersResponse response = userService.getFollowers(userId, pageable, search, cursorId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/listywave/user/repository/follow/custom/CustomFollowRepository.java
+++ b/src/main/java/com/listywave/user/repository/follow/custom/CustomFollowRepository.java
@@ -1,10 +1,13 @@
 package com.listywave.user.repository.follow.custom;
 
-import com.listywave.user.application.domain.Follow;
 import com.listywave.user.application.domain.User;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface CustomFollowRepository {
 
-    List<Follow> findAllByFollowingUserOrderByFollowerUserNicknameDesc(User user, int size, int cursorId);
+    Slice<User> findAllByFollowingUserOrderByFollowerUserNicknameAsc(User user, Pageable pageable, String search, String cursorId);
+
+    List<User> findAllByFollowerUserOrderByFollowingUserNicknameAsc(User user, String search);
 }

--- a/src/main/java/com/listywave/user/repository/user/custom/impl/CustomUserRepositoryImpl.java
+++ b/src/main/java/com/listywave/user/repository/user/custom/impl/CustomUserRepositoryImpl.java
@@ -1,12 +1,12 @@
 package com.listywave.user.repository.user.custom.impl;
 
+import static com.listywave.common.util.PaginationUtils.checkEndPage;
 import static com.listywave.list.application.domain.item.QItem.item;
 import static com.listywave.list.application.domain.list.QListEntity.listEntity;
 import static com.listywave.user.application.domain.QUser.user;
 
 import com.listywave.collaborator.application.domain.Collaborator;
 import com.listywave.collaborator.application.dto.CollaboratorResponse;
-import com.listywave.common.util.PaginationUtils;
 import com.listywave.list.application.domain.category.CategoryType;
 import com.listywave.list.application.domain.list.ListEntity;
 import com.listywave.user.application.domain.User;
@@ -46,7 +46,7 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
                 .orderBy(listEntity.updatedDate.desc())
                 .fetch();
 
-        return PaginationUtils.checkEndPage(pageable, fetch);
+        return checkEndPage(pageable, fetch);
     }
 
     private BooleanExpression collaboEq(List<Collaborator> collaborators, String type) {
@@ -135,6 +135,6 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
                 .limit(pageable.getPageSize() + 1)
                 .offset(pageable.getOffset())
                 .fetch();
-        return PaginationUtils.checkEndPage(pageable, fetch);
+        return checkEndPage(pageable, fetch);
     }
 }


### PR DESCRIPTION
# Description
- 팔로워 목록 검색 기능
  - 일단 기존 코드 리펙토링 진행하였습니다!!
  - 정렬이 닉네임 사전오름차순인데 cursorId는 사용자의 id로 되어 있어 매칭이 안돼 페이징이 안되는 현상이 있었습니다.
  -> 고로 cursorId를 nickname으로 하여 해결하였습니다! 
  - 검색 기능 부분 추가 하였습니다.
- 팔로잉 목록 검색 기능
  - 해당 부분은 페이징이 없어 검색 기능 부분만 추가 하였습니다!  
# Reference

# Relation Issues
- close #144 
