### PR TITLE
feat: 리스트 삭제 시, 히스토리 데이터도 삭제되도록 구현

### DIFF
--- a/src/main/java/com/listywave/history/repository/HistoryRepository.java
+++ b/src/main/java/com/listywave/history/repository/HistoryRepository.java
@@ -15,4 +15,6 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
             order by h.id
             """)
     List<History> findAllByList(ListEntity list);
+
+    void deleteAllByList(ListEntity list);
 }

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -158,6 +158,7 @@ public class ListService {
         replyRepository.deleteAllByCommentIn(comments);
         commentRepository.deleteAllInBatch(comments);
         listRepository.deleteById(listId);
+        historyRepository.deleteAllByList(list);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
# Description
리스트 삭제 시, 해당 리스트로부터 파생된 히스토리 데이터를 모두 삭제하도록 했습니다.
JPA 덕분에 코드 두 줄로 처리했네요!

# Relation Issues
- close #156 
