### PR TITLE
feat: 유효한 팔로우 요청인지 검증, 스스로를 팔로우하는 경우 검증, 최대 팔로우 수 검증, 팔로잉/팔로워 수 음수로 빠지는 것 방지

### DIFF
--- a/src/main/java/com/listywave/common/auth/AuthorizationInterceptor.java
+++ b/src/main/java/com/listywave/common/auth/AuthorizationInterceptor.java
@@ -48,6 +48,9 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
         if (isPreflight(request)) {
             return true;
         }
+        if (!(handler instanceof HandlerMethod)) {
+            return true;
+        }
 
         HandlerMethod handlerMethod = (HandlerMethod) handler;
         RequestMapping requestMapping = handlerMethod.getMethodAnnotation(RequestMapping.class);

--- a/src/main/java/com/listywave/common/exception/ErrorCode.java
+++ b/src/main/java/com/listywave/common/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     LENGTH_EXCEEDED(BAD_REQUEST, "최대 글자 길이를 초과하였습니다."),
     INVALID_COUNT(BAD_REQUEST, "선택한 아이템 및 라벨 및 콜라보레이터의 수가 올바르지 않습니다."),
     DUPLICATE_USER(BAD_REQUEST, "중복된 사용자를 선택할 수 없습니다."),
+    EXCEED_FOLLOW_COUNT_EXCEPTION(BAD_REQUEST, "요청할 수 있는 최대 사용자의 수를 초과했습니다."),
 
     // S3
     S3_DELETE_OBJECTS_EXCEPTION(INTERNAL_SERVER_ERROR, "S3의 이미지를 삭제 요청하는 과정에서 에러가 발생했습니다."),

--- a/src/main/java/com/listywave/common/exception/ErrorCode.java
+++ b/src/main/java/com/listywave/common/exception/ErrorCode.java
@@ -34,6 +34,8 @@ public enum ErrorCode {
     INVALID_COUNT(BAD_REQUEST, "선택한 아이템 및 라벨 및 콜라보레이터의 수가 올바르지 않습니다."),
     DUPLICATE_USER(BAD_REQUEST, "중복된 사용자를 선택할 수 없습니다."),
     EXCEED_FOLLOW_COUNT_EXCEPTION(BAD_REQUEST, "요청할 수 있는 최대 사용자의 수를 초과했습니다."),
+    ALREADY_FOLLOWED_EXCEPTION(BAD_REQUEST, "이미 팔로우를 하고 있습니다."),
+    ALREADY_NOT_FOLLOWED_EXCEPTION(BAD_REQUEST, "이미 팔로우가 되어 있지 않습니다."),
 
     // S3
     S3_DELETE_OBJECTS_EXCEPTION(INTERNAL_SERVER_ERROR, "S3의 이미지를 삭제 요청하는 과정에서 에러가 발생했습니다."),

--- a/src/main/java/com/listywave/user/application/domain/User.java
+++ b/src/main/java/com/listywave/user/application/domain/User.java
@@ -1,5 +1,6 @@
 package com.listywave.user.application.domain;
 
+import static com.listywave.common.exception.ErrorCode.EXCEED_FOLLOW_COUNT_EXCEPTION;
 import static com.listywave.common.exception.ErrorCode.INVALID_ACCESS;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -25,6 +26,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "users")
 @NoArgsConstructor(access = PROTECTED)
 public class User extends BaseEntity {
+
+    private static final int MAX_FOLLOW_COUNT = 1000;
 
     @Column(nullable = false)
     private Long oauthId;
@@ -107,13 +110,20 @@ public class User extends BaseEntity {
     }
 
     public void follow(User followingUser) {
+        if (this.followingCount == MAX_FOLLOW_COUNT) {
+            throw new CustomException(EXCEED_FOLLOW_COUNT_EXCEPTION, "팔로우는 최대 " + MAX_FOLLOW_COUNT + "명까지 가능합니다.");
+        }
         this.followingCount++;
         followingUser.followerCount++;
     }
 
     public void unfollow(User followingUser) {
-        this.followingCount--;
-        followingUser.followerCount--;
+        if (this.followingCount > 0) {
+            this.followingCount--;
+        }
+        if (followingUser.followerCount > 0) {
+            followingUser.followerCount--;
+        }
     }
 
     public void updateKakaoAccessToken(String kakaoAccessToken) {

--- a/src/main/java/com/listywave/user/application/domain/User.java
+++ b/src/main/java/com/listywave/user/application/domain/User.java
@@ -110,19 +110,35 @@ public class User extends BaseEntity {
     }
 
     public void follow(User followingUser) {
-        if (this.followingCount == MAX_FOLLOW_COUNT) {
-            throw new CustomException(EXCEED_FOLLOW_COUNT_EXCEPTION, "팔로우는 최대 " + MAX_FOLLOW_COUNT + "명까지 가능합니다.");
-        }
-        this.followingCount++;
-        followingUser.followerCount++;
+        this.increaseFollowingCount();
+        followingUser.increaseFollowerCount();
     }
 
     public void unfollow(User followingUser) {
+        this.decreaseFollowingCount();
+        followingUser.decreaseFollowerCount();
+    }
+
+    public void increaseFollowingCount() {
+        if (this.followingCount >= MAX_FOLLOW_COUNT) {
+            throw new CustomException(EXCEED_FOLLOW_COUNT_EXCEPTION, "팔로우는 최대 " + MAX_FOLLOW_COUNT + "명까지 가능합니다.");
+        }
+        this.followingCount++;
+    }
+
+    public void increaseFollowerCount() {
+        this.followerCount++;
+    }
+
+    public void decreaseFollowingCount() {
         if (this.followingCount > 0) {
             this.followingCount--;
         }
-        if (followingUser.followerCount > 0) {
-            followingUser.followerCount--;
+    }
+
+    public void decreaseFollowerCount() {
+        if (this.followerCount > 0) {
+            this.followerCount--;
         }
     }
 

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -1,5 +1,7 @@
 package com.listywave.user.application.service;
 
+import static com.listywave.common.exception.ErrorCode.ALREADY_FOLLOWED_EXCEPTION;
+import static com.listywave.common.exception.ErrorCode.ALREADY_NOT_FOLLOWED_EXCEPTION;
 import static com.listywave.common.exception.ErrorCode.INVALID_ACCESS;
 
 import com.listywave.alarm.application.domain.AlarmEvent;
@@ -94,7 +96,11 @@ public class UserService {
 
         User followingUser = userRepository.getById(followingUserId);
         User followerUser = userRepository.getById(followerUserId);
-        
+
+        if (followRepository.existsByFollowerUserAndFollowingUser(followerUser, followingUser)) {
+            throw new CustomException(ALREADY_FOLLOWED_EXCEPTION);
+        }
+
         followRepository.save(new Follow(followingUser, followerUser));
         followerUser.follow(followingUser);
         applicationEventPublisher.publishEvent(AlarmEvent.follow(followerUser, followingUser));
@@ -104,8 +110,11 @@ public class UserService {
         User followingUser = userRepository.getById(followingUserId);
         User followerUser = userRepository.getById(followerUserId);
 
-        followRepository.deleteByFollowingUserAndFollowerUser(followingUser, followerUser);
+        if (!followRepository.existsByFollowerUserAndFollowingUser(followerUser, followingUser)) {
+            throw new CustomException(ALREADY_NOT_FOLLOWED_EXCEPTION);
+        }
 
+        followRepository.deleteByFollowingUserAndFollowerUser(followingUser, followerUser);
         followerUser.unfollow(followingUser);
     }
 

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -1,8 +1,11 @@
 package com.listywave.user.application.service;
 
+import static com.listywave.common.exception.ErrorCode.INVALID_ACCESS;
+
 import com.listywave.alarm.application.domain.AlarmEvent;
 import com.listywave.collaborator.application.domain.Collaborator;
 import com.listywave.collaborator.repository.CollaboratorRepository;
+import com.listywave.common.exception.CustomException;
 import com.listywave.list.application.domain.category.CategoryType;
 import com.listywave.list.application.domain.list.ListEntity;
 import com.listywave.user.application.domain.Follow;
@@ -85,14 +88,15 @@ public class UserService {
     }
 
     public void follow(Long followingUserId, Long followerUserId) {
+        if (followingUserId.equals(followerUserId)) {
+            throw new CustomException(INVALID_ACCESS, "본인을 팔로우 할 수 없습니다.");
+        }
+
         User followingUser = userRepository.getById(followingUserId);
         User followerUser = userRepository.getById(followerUserId);
-
-        Follow follow = new Follow(followingUser, followerUser);
-        followRepository.save(follow);
-
+        
+        followRepository.save(new Follow(followingUser, followerUser));
         followerUser.follow(followingUser);
-
         applicationEventPublisher.publishEvent(AlarmEvent.follow(followerUser, followingUser));
     }
 


### PR DESCRIPTION
# 🚨 주의 🚨
머지됨에 따라 Follow 테이블을 초기화하고, User 테이블의 following_count, follower_count 필드를 모두 0으로 수정해야 합니다!

# 개요
[소현님 버그 리포팅](https://discord.com/channels/1193828040573198416/1197035601845833799/1209686414112067594)에 의해 확인해본 결과, 팔로우 요청과 팔로우 해제에 로직 상의 결함이 있는 것을 발견했습니다.

결함과 별개로 [팔로우 기능](https://github.com/8-Sprinters/ListyWave-back/pull/79)을 만들고 약간의 시간이 지나 [User 엔티티에 followingCount와 followerCount 값을 수정하는 로직을 추가](https://github.com/8-Sprinters/ListyWave-back/pull/101)했기 때문에 발생하지 않았나 싶습니다.

# 작업 내용
- 본인을 팔로우하는지 검증합니다.
- 최대 팔로우 수만큼 팔로우하고 있는지 검증합니다.
  - User 엔티티의 followingCount 필드로 검증하고 있습니다. 만약 DB와 동기화가 되어 있지 않은 상태라면 버그가 발생할 수 있습니다.
    따라서 추후 동기화 작업도 필요합니다.
- 기존에 팔로우를 하고 있는 상태인지? 혹은 하고 있지 않은 상태인지 검증합니다.
- User 엔티티의 followingCount, followerCount 값이 유효한 값으로 변경되는지 검사합니다.

# Relation Issues
- close #165 
