### PR TITLE
feat: 리스트 검색 시, 각 리스트에 대표 이미지 URL 추가하는 기능 구현

### DIFF
--- a/src/main/java/com/listywave/list/application/domain/item/Items.java
+++ b/src/main/java/com/listywave/list/application/domain/item/Items.java
@@ -151,4 +151,13 @@ public class Items {
     public List<Item> getValues() {
         return new ArrayList<>(values);
     }
+
+    public String getRepresentImageUrl() {
+        return sortByRank().values.stream()
+                .map(Item::getImageUrl)
+                .filter(ItemImageUrl::hasValue)
+                .map(ItemImageUrl::getValue)
+                .findFirst()
+                .orElse("");
+    }
 }

--- a/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
+++ b/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
@@ -201,4 +201,8 @@ public class ListEntity {
             throw new CustomException(RESOURCE_NOT_FOUND);
         }
     }
+
+    public String getRepresentImageUrl() {
+        return items.getRepresentImageUrl();
+    }
 }

--- a/src/main/java/com/listywave/list/application/dto/response/ListSearchResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/ListSearchResponse.java
@@ -14,7 +14,12 @@ public record ListSearchResponse(
         boolean hasNext
 ) {
 
-    public static ListSearchResponse of(List<ListEntity> lists, Long totalCount, Long cursorId, boolean hasNext) {
+    public static ListSearchResponse of(
+            List<ListEntity> lists,
+            Long totalCount,
+            Long cursorId,
+            boolean hasNext
+    ) {
         return ListSearchResponse.builder()
                 .resultLists(ListInfo.toList(lists))
                 .totalCount(totalCount)
@@ -34,7 +39,8 @@ record ListInfo(
         LocalDateTime updatedDate,
         Long ownerId,
         String ownerNickname,
-        String ownerProfileImageUrl
+        String ownerProfileImageUrl,
+        String representImageUrl
 ) {
 
     public static List<ListInfo> toList(List<ListEntity> lists) {
@@ -54,6 +60,7 @@ record ListInfo(
                 .ownerId(list.getUser().getId())
                 .ownerNickname(list.getUser().getNickname())
                 .ownerProfileImageUrl(list.getUser().getProfileImageUrl())
+                .representImageUrl(list.getRepresentImageUrl())
                 .build();
     }
 }


### PR DESCRIPTION
# Description
리스트 검색 시, 각 리스트에 대표 이미지 URL을 함께 응답하도록 구현했습니다.
높은 순위의 이미지가 최우선이며, 이미지가 없는 리스트의 경우 빈 문자열을 응답합니다.

# Relation Issues
- close #174 
