### PR TITLE
fix: 리스트 상세 조회 시, 아이템을 순위대로 정렬해서 응답하도록 구현

### DIFF
--- a/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
+++ b/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
@@ -108,13 +108,9 @@ public class ListEntity {
         this.updatedDate = LocalDateTime.now();
     }
 
-    public void sortItemsByRank() {
-        items = items.sortByRank();
+    public Items getSortItemsByRank() {
+        return items.sortByRank();
     }
-
-//    public void sortItemsByRankTop3() {
-//        items = items.sortByRankTop3();
-//    }
 
     public String getFirstItemImageUrl() {
         return items.getFirstImageUrl();

--- a/src/main/java/com/listywave/list/application/dto/response/ListDetailResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/ListDetailResponse.java
@@ -29,7 +29,13 @@ public record ListDetailResponse(
         int viewCount
 ) {
 
-    public static ListDetailResponse of(ListEntity list, User user, boolean isCollected, List<Collaborator> collaborators) {
+    public static ListDetailResponse of(
+            ListEntity list,
+            User user,
+            boolean isCollected,
+            List<Collaborator> collaborators,
+            List<Item> items
+    ) {
         return ListDetailResponse.builder()
                 .category(list.getCategory().getKorNameValue())
                 .labels(LabelResponse.toList(list.getLabels().getValues()))
@@ -41,7 +47,7 @@ public record ListDetailResponse(
                 .ownerNickname(user.getNickname())
                 .ownerProfileImageUrl(user.getProfileImageUrl())
                 .collaborators(CollaboratorResponse.toList(collaborators))
-                .items(ItemResponse.toList(list.getItems().getValues()))
+                .items(ItemResponse.toList(items))
                 .isCollected(isCollected)
                 .isPublic(list.isPublic())
                 .backgroundColor(list.getBackgroundColor())

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -126,18 +126,18 @@ public class ListService {
     public ListDetailResponse getListDetail(Long listId, Long loginUserId) {
         ListEntity list = listRepository.getById(listId);
         List<Collaborator> collaborators = collaboratorRepository.findAllByList(list);
+        Items sortedItems = list.getSortItemsByRank();
 
         boolean isCollected = false;
         if (loginUserId != null) {
             isCollected = collectionRepository.existsByListAndUserId(list, loginUserId);
         }
-        return ListDetailResponse.of(list, list.getUser(), isCollected, collaborators);
+        return ListDetailResponse.of(list, list.getUser(), isCollected, collaborators, sortedItems.getValues());
     }
 
     @Transactional(readOnly = true)
     public List<ListTrandingResponse> getTrandingList() {
         List<ListEntity> lists = listRepository.findTrandingLists();
-        lists.forEach(ListEntity::sortItemsByRank);
         return lists.stream()
                 .map(list -> ListTrandingResponse.of(list, list.getFirstItemImageUrl()))
                 .toList();


### PR DESCRIPTION
# Description
리스트 상세 조회 시, 아이템을 순서대로 정렬해서 응답하도록 구현했습니다.

#148 <- 해당 로직도 새로 추가한 메서드를 응용하면 될 것 같네요!

# Relation Issues
- close #176 
