### PR TITLE
fix: 댓글 조회 및 답글 생성 관련 버그 해결

### DIFF
--- a/src/main/java/com/listywave/list/presentation/controller/CommentController.java
+++ b/src/main/java/com/listywave/list/presentation/controller/CommentController.java
@@ -39,7 +39,7 @@ public class CommentController {
     ResponseEntity<CommentFindResponse> getAllCommentsByList(
             @PathVariable("listId") Long listId,
             @RequestParam(value = "size", defaultValue = "5") int size,
-            @RequestParam(value = "cursorId", defaultValue = "0") Long cursorId
+            @RequestParam(value = "cursorId", required = false) Long cursorId
     ) {
         CommentFindResponse response = commentService.getComments(listId, size, cursorId);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/listywave/list/presentation/controller/ReplyController.java
+++ b/src/main/java/com/listywave/list/presentation/controller/ReplyController.java
@@ -16,17 +16,15 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/lists/{listId}/comments/{commentId}/replies")
 public class ReplyController {
 
     private final ReplyService replyService;
 
-    @PostMapping
+    @PostMapping("/lists/{listId}/comments/{commentId}/replies")
     ResponseEntity<ReplyCreateResponse> create(
             @PathVariable("listId") Long listId,
             @PathVariable("commentId") Long commentId,
@@ -37,7 +35,7 @@ public class ReplyController {
         return ResponseEntity.status(CREATED).body(response);
     }
 
-    @DeleteMapping("/{replyId}")
+    @DeleteMapping("/lists/{listId}/comments/{commentId}/replies/{replyId}")
     ResponseEntity<Void> deleteReply(
             @PathVariable("listId") Long listId,
             @PathVariable("commentId") Long commentId,
@@ -49,7 +47,7 @@ public class ReplyController {
         return ResponseEntity.noContent().build();
     }
 
-    @PatchMapping("/{replyId}")
+    @PatchMapping("/lists/{listId}/comments/{commentId}/replies/{replyId}")
     ResponseEntity<Void> updateReply(
             @PathVariable("listId") Long listId,
             @PathVariable("commentId") Long commentId,

--- a/src/main/java/com/listywave/list/repository/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/listywave/list/repository/CustomCommentRepositoryImpl.java
@@ -3,10 +3,10 @@ package com.listywave.list.repository;
 
 import static com.listywave.list.application.domain.comment.QComment.comment;
 import static com.listywave.list.application.domain.list.QListEntity.listEntity;
-import static com.listywave.list.application.domain.reply.QReply.reply;
 
 import com.listywave.list.application.domain.comment.Comment;
 import com.listywave.list.application.domain.list.ListEntity;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,15 +19,21 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository {
     @Override
     public List<Comment> getComments(ListEntity list, int size, Long cursorId) {
         return queryFactory.selectFrom(comment)
-                .join(listEntity).fetchJoin().on(listEntity.id.eq(comment.list.id))
-                .join(reply).fetchJoin().on(comment.id.eq(reply.comment.id))
+                .leftJoin(listEntity).on(comment.list.id.eq(listEntity.id)).fetchJoin()
                 .where(
-                        listEntity.id.eq(list.getId()),
-                        comment.id.gt(cursorId),
+                        comment.list.id.eq(list.getId()),
+                        commentIdGt(cursorId),
                         comment.user.isDelete.eq(false)
                 )
                 .orderBy(comment.id.asc())
                 .limit(size + 1)
                 .fetch();
+    }
+
+    private static BooleanExpression commentIdGt(Long cursorId) {
+        if (cursorId == null) {
+            return null;
+        }
+        return comment.id.gt(cursorId);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        use_sql_comments: true
         highlight_sql: true
         default_batch_fetch_size: 100
       show-sql: true


### PR DESCRIPTION
# Description
1. 댓글 조회 시, reply 테이블과 inner join으로 인해 실패하는 오류를 해결했습니다.
2. 답글 생성 시, AuthorizationInterceptor에 의해 실패하는 문제를 해결했습니다.

# Relation Issues
- close #186 
