### PR TITLE
refactor: 수정한 필드 값만 요청으로 받아 수정되도록 리팩터링

### DIFF
--- a/src/main/java/com/listywave/user/application/domain/User.java
+++ b/src/main/java/com/listywave/user/application/domain/User.java
@@ -86,10 +86,18 @@ public class User extends BaseEntity {
             String profileImageUrl,
             String backgroundImageUrl
     ) {
-        this.nickname = new Nickname(nickname);
-        this.description = new Description(description);
-        this.profileImageUrl = new ProfileImageUrl(profileImageUrl);
-        this.backgroundImageUrl = new BackgroundImageUrl(backgroundImageUrl);
+        if (nickname != null) {
+            this.nickname = new Nickname(nickname);
+        }
+        if (description != null) {
+            this.description = new Description(description);
+        }
+        if (profileImageUrl != null) {
+            this.profileImageUrl = new ProfileImageUrl(profileImageUrl);
+        }
+        if (backgroundImageUrl != null) {
+            this.backgroundImageUrl = new BackgroundImageUrl(backgroundImageUrl);
+        }
     }
 
     public void updateUserImageUrl(String profileImage, String backgroundImage) {


### PR DESCRIPTION
# Description
- 기존에는 프로필에서 하나만 수정되어도 다른 기존 필드값도 다 가져갔었는데 소현님의 요청으로 수정한 값만 필드에 포함되서 가져가면 프론트단에 코드가 많이 줄어들며, 최초 온보딩 시 닉네임 수정만 보내야 되는데 그럴 경우에도 사용이 가능해져 편하다라는 요청으로 인하여 수정된 필드만 가져올 시 해당 부분만 수정 되도록 리펙토링 하였습니다.

# Reference

# Relation Issues
- close #191 
