### PR TITLE
fix: 트랜딩, 최근리스트, 검색결과에 비공개 리스트가 나타나는 버그 수정

### DIFF
--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -196,7 +196,7 @@ public class ListService {
 
     public ListSearchResponse search(String keyword, SortType sortType, CategoryType category, int size, Long cursorId) {
         List<ListEntity> lists = listRepository.findAll().stream()
-                .filter(user -> !user.isDeletedUser())
+                .filter(list -> !list.isDeletedUser() && list.isPublic())
                 .toList();
         ListEntities allList = new ListEntities(lists);
         ListEntities filtered = allList.filterBy(category)

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -238,6 +238,7 @@ public class ListService {
         list.update(user, request.category(), new ListTitle(request.title()), new ListDescription(request.description()), request.isPublic(), request.backgroundColor(), hasCollaborator, updatedDate, labels, newItems);
 
         if (hasCollaborator) {
+            collaboratorIds.add(list.getUser().getId());
             Collaborators collaborators = createCollaborators(collaboratorIds, list);
             collaboratorRepository.saveAll(collaborators.getCollaborators());
         }

--- a/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
@@ -30,7 +30,11 @@ public class CustomListRepositoryImpl implements CustomListRepository {
                 .selectFrom(listEntity)
                 .join(listEntity.user, user).fetchJoin()
                 .leftJoin(item).on(listEntity.id.eq(item.list.id))
-                .where(listEntity.updatedDate.goe(thirtyDaysAgo))
+                .where(
+                        listEntity.updatedDate.goe(thirtyDaysAgo),
+                        listEntity.isPublic.eq(true),
+                        listEntity.user.isDelete.eq(false)
+                )
                 .distinct()
                 .limit(10)
                 .orderBy(listEntity.collectCount.desc(), listEntity.viewCount.desc(), listEntity.id.desc())
@@ -49,7 +53,8 @@ public class CustomListRepositoryImpl implements CustomListRepository {
                 .where(
                         listEntity.updatedDate.goe(thirtyDaysAgo),
                         listIdLt(cursorId),
-                        listEntity.user.isDelete.eq(false)
+                        listEntity.user.isDelete.eq(false),
+                        listEntity.isPublic.eq(true)
                 )
                 .distinct()
                 .limit(pageable.getPageSize() + 1)
@@ -75,7 +80,8 @@ public class CustomListRepositoryImpl implements CustomListRepository {
                 .where(
                         listEntity.updatedDate.goe(thirtyDaysAgo),
                         listEntity.user.id.in(followingUserIds),
-                        listIdLt(cursorId)
+                        listIdLt(cursorId),
+                        listEntity.isPublic.eq(true)
                 )
                 .distinct()
                 .limit(pageable.getPageSize() + 1)


### PR DESCRIPTION
# Description
- **트랜딩, 최근리스트, 검색결과에 비공개 리스트가 나타나지 않도록 수정하였습니다.**
- **리스트 수정할때 콜라보를 재등록하는데 리스트 등록자(owner)가 콜라보 등록에 빠진 부분 수정 하였습니다.**
  - 동호님 질문 사항이 있는데 리스트 수정 시 Label이나 Item은 기존꺼 삭제되고 재등록 되는 거 같은데 collaborator는 기존에 있는 거 삭제 되는 로직이 없는 거 같아서요 ( 콜라보 리스트 수정할 때 request에 `List<Long> collaborators`는 리스트 owner를 제외한 애들이 오는데 이때 본인을 콜라보에서 빼거나 누군가를 추가할 수 있기에 기존 collabo삭제 되고 다시 재등록 하는 게 필요해 보임 -> 참고로 리스트 생성자는 콜라보에서 못뺌)
  - 그리고 도메인에서의 update 처리 보면 validate부분이 해당 리스트owner와 로그인 유저가 일치 하는지 검증이 되어 있는데 이 경우에는 리스트owner가 아닌 콜라보레이터들이 콜라보리스트를 수정하는 경우 에러가 발생할 요지가 보입니다!
  -> 해당 문제들은 이 PR을 merge한 후 동호님이 이슈를 재 생성해서 처리해야 할 거 같습니다!
# Reference

# Relation Issues
- close #200 
