### PR TITLE
feat: 중복 로그아웃 예외 처리

### DIFF
--- a/src/main/java/com/listywave/auth/application/service/AuthService.java
+++ b/src/main/java/com/listywave/auth/application/service/AuthService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class AuthService {
 
@@ -30,7 +31,6 @@ public class AuthService {
         return kakaoRedirectUriProvider.provide();
     }
 
-    @Transactional
     public LoginResult login(String authCode) {
         KakaoTokenResponse kakaoTokenResponse = kakaoOauthClient.requestToken(authCode);
         KakaoMember kakaoMember = kakaoOauthClient.fetchMember(kakaoTokenResponse.accessToken());
@@ -64,7 +64,9 @@ public class AuthService {
 
     public void logout(Long userId) {
         User user = userRepository.getById(userId);
+        user.validateHasKakaoAccessToken();
         kakaoOauthClient.logout(user.getKakaoAccessToken());
+        user.updateKakaoAccessToken("");
     }
 
     public UpdateTokenResult updateToken(String refreshToken) {

--- a/src/main/java/com/listywave/common/exception/ErrorCode.java
+++ b/src/main/java/com/listywave/common/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     ALREADY_FOLLOWED_EXCEPTION(BAD_REQUEST, "이미 팔로우를 하고 있습니다."),
     ALREADY_NOT_FOLLOWED_EXCEPTION(BAD_REQUEST, "이미 팔로우가 되어 있지 않습니다."),
     DELETED_USER_EXCEPTION(BAD_REQUEST, "탈퇴한 회원입니다."),
+    ALREADY_LOGOUT_EXCEPTION(BAD_REQUEST, "이미 로그아웃 처리가 된 상태입니다."),
 
     // S3
     S3_DELETE_OBJECTS_EXCEPTION(INTERNAL_SERVER_ERROR, "S3의 이미지를 삭제 요청하는 과정에서 에러가 발생했습니다."),

--- a/src/main/java/com/listywave/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/listywave/common/exception/GlobalExceptionHandler.java
@@ -19,7 +19,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @RequiredArgsConstructor
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-    @ExceptionHandler
+    @ExceptionHandler(CustomException.class)
     ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
         String message = e.getErrorCode().getDetail();
         log.error("[CustomException] : {}", message, e);

--- a/src/main/java/com/listywave/user/application/domain/User.java
+++ b/src/main/java/com/listywave/user/application/domain/User.java
@@ -1,5 +1,6 @@
 package com.listywave.user.application.domain;
 
+import static com.listywave.common.exception.ErrorCode.ALREADY_LOGOUT_EXCEPTION;
 import static com.listywave.common.exception.ErrorCode.EXCEED_FOLLOW_COUNT_EXCEPTION;
 import static com.listywave.common.exception.ErrorCode.INVALID_ACCESS;
 import static lombok.AccessLevel.PROTECTED;
@@ -162,6 +163,12 @@ public class User extends BaseEntity {
 
     public void updateKakaoAccessToken(String kakaoAccessToken) {
         this.kakaoAccessToken = kakaoAccessToken;
+    }
+
+    public void validateHasKakaoAccessToken() {
+        if (kakaoAccessToken == null || kakaoAccessToken.isBlank()) {
+            throw new CustomException(ALREADY_LOGOUT_EXCEPTION);
+        }
     }
 
     public String getNickname() {


### PR DESCRIPTION
# Description
기존 같은 토큰으로 중복 로그아웃 요청을 보내면 500 에러가 발생했습니다.
이제는 `400 Bad Request`로 응답하도록 구현했습니다.

# Relation Issues
- close #196 
