### PR TITLE
feat: 콜라보레이터 변경 및 리스트 수정의 인가 권한 변경

### DIFF
--- a/src/main/java/com/listywave/collaborator/application/domain/Collaborator.java
+++ b/src/main/java/com/listywave/collaborator/application/domain/Collaborator.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,11 +40,28 @@ public class Collaborator {
         return new Collaborator(null, user, list);
     }
 
+    public boolean hasUser(User other) {
+        return this.user.equals(other);
+    }
+
     public String getUserNickname() {
         return user.getNickname();
     }
 
     public String getUserProfileImageUrl() {
         return user.getProfileImageUrl();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Collaborator that = (Collaborator) o;
+        return Objects.equals(getUser(), that.getUser()) && Objects.equals(getList(), that.getList());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getUser(), getList());
     }
 }

--- a/src/main/java/com/listywave/collaborator/application/domain/Collaborators.java
+++ b/src/main/java/com/listywave/collaborator/application/domain/Collaborators.java
@@ -1,15 +1,19 @@
 package com.listywave.collaborator.application.domain;
 
+import static com.listywave.common.exception.ErrorCode.INVALID_ACCESS;
 import static com.listywave.common.exception.ErrorCode.INVALID_COUNT;
 
 import com.listywave.common.exception.CustomException;
+import com.listywave.user.application.domain.User;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class Collaborators {
 
     private static final int MAX_SIZE = 20;
-    
+
     private final List<Collaborator> collaborators;
 
     public Collaborators(List<Collaborator> collaborators) {
@@ -21,6 +25,33 @@ public class Collaborators {
         if (collaborators.size() > MAX_SIZE) {
             throw new CustomException(INVALID_COUNT);
         }
+    }
+
+    public void validateListUpdateAuthority(User user) {
+        if (!contains(user)) {
+            throw new CustomException(INVALID_ACCESS, "리스트 수정은 작성자 혹은 콜라보레이터만 가능합니다.");
+        }
+    }
+
+    public Collaborators filterRemovedCollaborators(Collaborators newCollaborators) {
+        Set<Collaborator> before = new HashSet<>(this.collaborators);
+        newCollaborators.collaborators.forEach(before::remove);
+        return new Collaborators(new ArrayList<>(before));
+    }
+
+    public Collaborators filterAddedCollaborators(Collaborators newCollaborators) {
+        Set<Collaborator> after = new HashSet<>(newCollaborators.collaborators);
+        this.collaborators.forEach(after::remove);
+        return new Collaborators(new ArrayList<>(after));
+    }
+
+    public boolean contains(User user) {
+        return collaborators.stream()
+                .anyMatch(collaborator -> collaborator.hasUser(user));
+    }
+
+    public void add(Collaborator collaborator) {
+        collaborators.add(collaborator);
     }
 
     public List<Collaborator> getCollaborators() {

--- a/src/test/java/com/listywave/collaborator/application/domain/CollaboratorsTest.java
+++ b/src/test/java/com/listywave/collaborator/application/domain/CollaboratorsTest.java
@@ -1,0 +1,163 @@
+package com.listywave.collaborator.application.domain;
+
+import static com.listywave.list.application.domain.category.CategoryType.ETC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.listywave.common.exception.CustomException;
+import com.listywave.list.application.domain.item.Item;
+import com.listywave.list.application.domain.item.ItemComment;
+import com.listywave.list.application.domain.item.ItemImageUrl;
+import com.listywave.list.application.domain.item.ItemLink;
+import com.listywave.list.application.domain.item.ItemTitle;
+import com.listywave.list.application.domain.item.Items;
+import com.listywave.list.application.domain.label.Labels;
+import com.listywave.list.application.domain.list.ListDescription;
+import com.listywave.list.application.domain.list.ListEntity;
+import com.listywave.list.application.domain.list.ListTitle;
+import com.listywave.user.application.domain.User;
+import java.util.List;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.Test;
+
+class CollaboratorsTest {
+
+    @Test
+    void 콜라보레이터는_최대_20명까지_등록가능하다() {
+        // given
+        List<Collaborator> collaborators = LongStream.range(0, 20)
+                .mapToObj(i -> {
+                    User user = User.init(i, String.valueOf(i), String.valueOf(i));
+                    ListEntity list = new ListEntity(
+                            user,
+                            ETC,
+                            new ListTitle(String.valueOf(i)),
+                            new ListDescription(String.valueOf(i)),
+                            true,
+                            String.valueOf(i),
+                            false,
+                            new Labels(List.of()),
+                            new Items(List.of(
+                                    Item.init((int) i, new ItemTitle(String.valueOf(i)), new ItemComment(String.valueOf(i)), new ItemLink(String.valueOf(i)), new ItemImageUrl(String.valueOf(i))),
+                                    Item.init((int) i + 1, new ItemTitle(String.valueOf(i)), new ItemComment(String.valueOf(i)), new ItemLink(String.valueOf(i)), new ItemImageUrl(String.valueOf(i))),
+                                    Item.init((int) i + 2, new ItemTitle(String.valueOf(i)), new ItemComment(String.valueOf(i)), new ItemLink(String.valueOf(i)), new ItemImageUrl(String.valueOf(i)))
+                            ))
+                    );
+                    return Collaborator.init(user, list);
+                }).toList();
+
+        // then
+        assertDoesNotThrow(() -> new Collaborators(collaborators));
+    }
+
+    @Test
+    void 등록하는_콜라보레이터가_20명이_넘으면_예외가_발생한다() {
+        // given
+        List<Collaborator> collaborators = LongStream.range(0, 21)
+                .mapToObj(i -> {
+                    User user = User.init(i, String.valueOf(i), String.valueOf(i));
+                    ListEntity list = new ListEntity(
+                            user,
+                            ETC,
+                            new ListTitle(String.valueOf(i)),
+                            new ListDescription(String.valueOf(i)),
+                            true,
+                            String.valueOf(i),
+                            false,
+                            new Labels(List.of()),
+                            new Items(List.of(
+                                    Item.init((int) i, new ItemTitle(String.valueOf(i)), new ItemComment(String.valueOf(i)), new ItemLink(String.valueOf(i)), new ItemImageUrl(String.valueOf(i))),
+                                    Item.init((int) i + 1, new ItemTitle(String.valueOf(i)), new ItemComment(String.valueOf(i)), new ItemLink(String.valueOf(i)), new ItemImageUrl(String.valueOf(i))),
+                                    Item.init((int) i + 2, new ItemTitle(String.valueOf(i)), new ItemComment(String.valueOf(i)), new ItemLink(String.valueOf(i)), new ItemImageUrl(String.valueOf(i)))
+                            ))
+                    );
+                    return Collaborator.init(user, list);
+                }).toList();
+
+        // then
+        assertThrows(CustomException.class, () -> new Collaborators(collaborators));
+    }
+
+    @Test
+    void 리스트를_수정할_수_있는_사용자인지_검증한다() {
+        // given
+        User userA = User.init(1L, "aaaa@naver.com", "aaaa");
+        User userB = User.init(2L, "bbbb@naver.com", "bbbb");
+        ListEntity list = new ListEntity(userA, ETC, new ListTitle("title"), new ListDescription("description"), true, "#123345", true, new Labels(List.of()), new Items(List.of(
+                Item.init(1, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
+                Item.init(2, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
+                Item.init(3, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1)))
+        )));
+
+        Collaborators collaborators = new Collaborators(List.of(
+                Collaborator.init(userA, list),
+                Collaborator.init(userB, list)
+        ));
+
+        // then
+        User userC = User.init(3L, "cccc@naver.com", "cccc");
+        assertThrows(CustomException.class, () -> collaborators.validateListUpdateAuthority(userC));
+
+        assertDoesNotThrow(() -> collaborators.validateListUpdateAuthority(userA));
+    }
+
+    @Test
+    void 삭제되는_콜라보레이터를_필터링한다() {
+        // given
+        User userA = User.init(1L, "aaaa@naver.com", "aaaa");
+        User userB = User.init(2L, "bbbb@naver.com", "bbbb");
+        User userC = User.init(3L, "cccc@naver.com", "cccc");
+        User userD = User.init(4L, "dddd@naver.com", "dddd");
+
+        ListEntity list = new ListEntity(userA, ETC, new ListTitle("title"), new ListDescription("description"), true, "#123345", true, new Labels(List.of()), new Items(List.of(
+                Item.init(1, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
+                Item.init(2, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
+                Item.init(3, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1)))
+        )));
+
+        Collaborators beforeCollaborators = new Collaborators(List.of(
+                Collaborator.init(userA, list),
+                Collaborator.init(userB, list),
+                Collaborator.init(userC, list),
+                Collaborator.init(userD, list)
+        ));
+
+        // when
+        Collaborators newCollaborators = new Collaborators(List.of(
+                Collaborator.init(userA, list),
+                Collaborator.init(userD, list)
+        ));
+        Collaborators result = beforeCollaborators.filterRemovedCollaborators(newCollaborators);
+
+        // then
+        assertThat(result.getCollaborators()).hasSize(2);
+        assertThat(result.getCollaborators().stream().map(Collaborator::getUser)).containsOnly(userB, userC);
+    }
+
+    @Test
+    void 새로_추가되는_콜라보레이터를_필터링한다() {
+        User userA = User.init(1L, "aaaa@naver.com", "aaaa");
+        User userC = User.init(3L, "cccc@naver.com", "cccc");
+
+        ListEntity list = new ListEntity(userA, ETC, new ListTitle("title"), new ListDescription("description"), true, "#123345", true, new Labels(List.of()), new Items(List.of(
+                Item.init(1, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
+                Item.init(2, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
+                Item.init(3, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1)))
+        )));
+
+        Collaborators beforeCollaborators = new Collaborators(List.of(
+        ));
+
+        // when
+        Collaborators newCollaborators = new Collaborators(List.of(
+                Collaborator.init(userA, list),
+                Collaborator.init(userC, list)
+        ));
+        Collaborators result = beforeCollaborators.filterAddedCollaborators(newCollaborators);
+
+        // then
+        assertThat(result.getCollaborators()).hasSize(2);
+        assertThat(result.getCollaborators().stream().map(Collaborator::getUser)).containsOnly(userA, userC);
+    }
+}


### PR DESCRIPTION
# Description
1. 리스트 수정 시, 콜라보레이터의 변경(삭제)가 일어날 때 DB에 반영하지 않던 것을 반영했습니다.
2. 리스트 수정의 인가 권한 범위를 List Owner에서 Collaborators로 수정했습니다.

# Relation Issues
- close #202 
