### PR TITLE
 fix: 댓글 조회 시, 집계가 잘못되던 문제 해결

### DIFF
--- a/src/main/java/com/listywave/list/repository/CommentRepository.java
+++ b/src/main/java/com/listywave/list/repository/CommentRepository.java
@@ -18,8 +18,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, CustomC
 
     List<Comment> findAllByList(ListEntity list);
 
-    Long countByList(ListEntity list);
-
     @Query("select c from Comment c where c.list in :lists")
     List<Comment> findAllByListIn(@Param("lists") List<ListEntity> lists);
 }

--- a/src/main/java/com/listywave/list/repository/CustomCommentRepository.java
+++ b/src/main/java/com/listywave/list/repository/CustomCommentRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface CustomCommentRepository {
 
     List<Comment> getComments(ListEntity list, int size, Long cursorId);
+
+    Long countByList(ListEntity list);
 }

--- a/src/main/java/com/listywave/list/repository/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/listywave/list/repository/CustomCommentRepositoryImpl.java
@@ -36,4 +36,18 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository {
         }
         return comment.id.gt(cursorId);
     }
+
+    @Override
+    public Long countByList(ListEntity list) {
+        return queryFactory
+                .select(comment.count())
+                .from(comment)
+                .leftJoin(listEntity).on(comment.list.id.eq(listEntity.id))
+                .where(
+                        comment.list.id.eq(list.getId()),
+                        comment.isDeleted.isFalse(),
+                        comment.user.isDelete.isFalse()
+                )
+                .fetchOne();
+    }
 }

--- a/src/main/java/com/listywave/list/repository/reply/CustomReplyRepositoryImpl.java
+++ b/src/main/java/com/listywave/list/repository/reply/CustomReplyRepositoryImpl.java
@@ -14,11 +14,14 @@ public class CustomReplyRepositoryImpl implements CustomReplyRepository {
     private final JPAQueryFactory queryFactory;
 
     public Long countByList(ListEntity list) {
-        return queryFactory.select(reply.count())
+        return queryFactory
+                .select(reply.count())
                 .from(reply)
-                .leftJoin(comment).on(comment.id.eq(reply.id))
+                .leftJoin(comment).on(comment.id.eq(reply.comment.id))
                 .leftJoin(listEntity).on(listEntity.id.eq(comment.list.id))
-                .where(listEntity.id.eq(list.getId()))
+                .where(
+                        listEntity.id.eq(list.getId())
+                )
                 .fetchOne();
     }
 }


### PR DESCRIPTION
# Description
댓글 집계는 `총 댓글 + 총 답글 - 삭제 상태인 댓글`로 계산했습니다.

# Relation Issues
- close #203 
