### PR TITLE
fix: 탈퇴한 회원의 데이터와 관련된 버그 해결

### DIFF
--- a/src/main/java/com/listywave/collection/application/service/CollectionService.java
+++ b/src/main/java/com/listywave/collection/application/service/CollectionService.java
@@ -32,7 +32,7 @@ public class CollectionService {
         User loginUser = userRepository.getById(loginUserId);
         ListEntity list = listRepository.getById(listId);
 
-        list.validateOwnerRestriction(loginUser);
+        list.validateOwner(loginUser);
 
         if (collectionRepository.existsByListAndUserId(list, loginUser.getId())) {
             cancelCollect(list, loginUser.getId());
@@ -44,14 +44,14 @@ public class CollectionService {
     private void addCollect(ListEntity list, User user) {
         Collect collection = new Collect(list, user.getId());
         collectionRepository.save(collection);
-        list.incrementCollectCount();
+        list.increaseCollectCount();
 
         applicationEventPublisher.publishEvent(AlarmEvent.collect(user, list));
     }
 
     private void cancelCollect(ListEntity list, Long userId) {
         collectionRepository.deleteByListAndUserId(list, userId);
-        list.decrementCollectCount();
+        list.decreaseCollectCount();
     }
 
     public CollectionResponse getCollection(Long loginUserId, Long cursorId, Pageable pageable, CategoryType category) {

--- a/src/main/java/com/listywave/collection/application/service/CollectionService.java
+++ b/src/main/java/com/listywave/collection/application/service/CollectionService.java
@@ -32,7 +32,7 @@ public class CollectionService {
         User loginUser = userRepository.getById(loginUserId);
         ListEntity list = listRepository.getById(listId);
 
-        list.validateOwner(loginUser);
+        list.validateNotOwner(loginUser);
 
         if (collectionRepository.existsByListAndUserId(list, loginUser.getId())) {
             cancelCollect(list, loginUser.getId());

--- a/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
+++ b/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
@@ -155,11 +155,11 @@ public class ListEntity {
         return totalScore;
     }
 
-    public void incrementCollectCount() {
+    public void increaseCollectCount() {
         this.collectCount++;
     }
 
-    public void decrementCollectCount() {
+    public void decreaseCollectCount() {
         this.collectCount--;
     }
 

--- a/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
+++ b/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
@@ -1,5 +1,6 @@
 package com.listywave.list.application.domain.list;
 
+import static com.listywave.common.exception.ErrorCode.DELETED_USER_EXCEPTION;
 import static com.listywave.common.exception.ErrorCode.INVALID_ACCESS;
 import static com.listywave.common.exception.ErrorCode.RESOURCE_NOT_FOUND;
 import static com.listywave.list.application.domain.category.CategoryType.ENTIRE;
@@ -212,5 +213,11 @@ public class ListEntity {
 
     public boolean isDeletedUser() {
         return user.getIsDelete();
+    }
+
+    public void validateDoesNotDeleteOwner() {
+        if (this.user.getIsDelete()) {
+            throw new CustomException(DELETED_USER_EXCEPTION, "탈퇴한 회원의 리스트입니다.");
+        }
     }
 }

--- a/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
+++ b/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
@@ -127,6 +127,12 @@ public class ListEntity {
         }
     }
 
+    public void validateNotOwner(User user) {
+        if (this.user.equals(user)) {
+            throw new CustomException(INVALID_ACCESS);
+        }
+    }
+
     public boolean isCategoryType(CategoryType category) {
         return category.equals(ENTIRE) || this.category.equals(category);
     }

--- a/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
+++ b/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
@@ -126,12 +126,6 @@ public class ListEntity {
         }
     }
 
-    public void validateOwnerRestriction(User user) {
-        if (this.user.equals(user)) {
-            throw new CustomException(INVALID_ACCESS);
-        }
-    }
-
     public boolean isCategoryType(CategoryType category) {
         return category.equals(ENTIRE) || this.category.equals(category);
     }

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -132,6 +132,7 @@ public class ListService {
 
     public ListDetailResponse getListDetail(Long listId, Long loginUserId) {
         ListEntity list = listRepository.getById(listId);
+        list.validateDoesNotDeleteOwner();
         List<Collaborator> collaborators = collaboratorRepository.findAllByList(list);
         Items sortedItems = list.getSortedItems();
 

--- a/src/main/java/com/listywave/list/repository/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/listywave/list/repository/CustomCommentRepositoryImpl.java
@@ -23,7 +23,7 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository {
                 .where(
                         comment.list.id.eq(list.getId()),
                         commentIdGt(cursorId),
-                        comment.user.isDelete.eq(false)
+                        comment.user.isDelete.isFalse()
                 )
                 .orderBy(comment.id.asc())
                 .limit(size + 1)

--- a/src/main/java/com/listywave/list/repository/list/custom/CustomListRepository.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/CustomListRepository.java
@@ -24,4 +24,6 @@ public interface CustomListRepository {
             Long cursorId,
             Pageable pageable
     );
+
+    List<ListEntity> findAllCollectedListBy(Long userId);
 }

--- a/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
@@ -117,7 +117,8 @@ public class CustomListRepositoryImpl implements CustomListRepository {
                         userIdEq(userId, type),
                         typeEq(type),
                         categoryEq(category),
-                        listIdLt(cursorId)
+                        listIdLt(cursorId),
+                        listEntity.user.isDelete.isFalse()
                 )
                 .distinct()
                 .limit(pageable.getPageSize() + 1)

--- a/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.listywave.list.repository.list.custom.impl;
 
+import static com.listywave.collection.application.domain.QCollect.collect;
 import static com.listywave.common.exception.ErrorCode.NOT_SUPPORT_FILTER_ARGUMENT_EXCEPTION;
 import static com.listywave.common.util.PaginationUtils.checkEndPage;
 import static com.listywave.list.application.domain.category.CategoryType.ENTIRE;
@@ -159,5 +160,15 @@ public class CustomListRepositoryImpl implements CustomListRepository {
             return null;
         }
         return listEntity.category.eq(category);
+    }
+
+    @Override
+    public List<ListEntity> findAllCollectedListBy(Long userId) {
+        return queryFactory.selectFrom(listEntity)
+                .leftJoin(collect).on(collect.list.id.eq(listEntity.id))
+                .where(
+                        collect.userId.eq(userId)
+                )
+                .fetch();
     }
 }

--- a/src/main/java/com/listywave/list/repository/reply/CustomReplyRepositoryImpl.java
+++ b/src/main/java/com/listywave/list/repository/reply/CustomReplyRepositoryImpl.java
@@ -20,7 +20,8 @@ public class CustomReplyRepositoryImpl implements CustomReplyRepository {
                 .leftJoin(comment).on(comment.id.eq(reply.comment.id))
                 .leftJoin(listEntity).on(listEntity.id.eq(comment.list.id))
                 .where(
-                        listEntity.id.eq(list.getId())
+                        listEntity.id.eq(list.getId()),
+                        reply.user.isDelete.isFalse()
                 )
                 .fetchOne();
     }

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -163,12 +163,15 @@ public class UserService {
         user.softDelete();
 
         followRepository.getAllByFollowerUser(user).stream()
-                .map(Follow::getFollowingUser) // 탈퇴하는 회원이 팔로우 하는 회원들 모두 조회해서
+                .map(Follow::getFollowingUser)
                 .forEach(User::decreaseFollowerCount);
 
         followRepository.getAllByFollowingUser(user).stream()
                 .map(Follow::getFollowerUser)
                 .forEach(User::decreaseFollowingCount);
+
+        List<ListEntity> lists = listRepository.findAllCollectedListBy(userId);
+        lists.forEach(ListEntity::decreaseCollectCount);
     }
 
     public void updateListVisibility(Long loginUserId, Long listId, Boolean beforeIsPublic) {

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -63,8 +63,8 @@ public class UserService {
     }
 
     private AllUserSearchResponse getAllUserSearchResponse(Long loginUserId, String search, Pageable pageable) {
-        Long count = userRepository.getCollaboratorCount(search, loginUserId);
-        Slice<UserSearchResponse> users = userRepository.getCollaborators(search, pageable, loginUserId);
+        Long count = userRepository.countBySearch(search, loginUserId);
+        Slice<UserSearchResponse> users = userRepository.findAllBySearch(search, pageable, loginUserId);
         return AllUserSearchResponse.of(users.getContent(), count, users.hasNext());
     }
 

--- a/src/main/java/com/listywave/user/repository/user/custom/CustomUserRepository.java
+++ b/src/main/java/com/listywave/user/repository/user/custom/CustomUserRepository.java
@@ -10,7 +10,7 @@ public interface CustomUserRepository {
 
     List<User> getRecommendUsers(List<User> myFollowingUsers, User user);
 
-    Long getCollaboratorCount(String search, Long loginUserId);
+    Long countBySearch(String search, Long loginUserId);
 
-    Slice<UserSearchResponse> getCollaborators(String search, Pageable pageable, Long loginUserId);
+    Slice<UserSearchResponse> findAllBySearch(String search, Pageable pageable, Long loginUserId);
 }

--- a/src/main/java/com/listywave/user/repository/user/custom/impl/CustomUserRepositoryImpl.java
+++ b/src/main/java/com/listywave/user/repository/user/custom/impl/CustomUserRepositoryImpl.java
@@ -43,7 +43,7 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
     }
 
     @Override
-    public Long getCollaboratorCount(String search, Long loginUserId) {
+    public Long countBySearch(String search, Long loginUserId) {
         if (search.isEmpty()) {
             return 0L;
         }
@@ -52,13 +52,18 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
                 .from(user)
                 .where(
                         userIdNe(loginUserId),
-                        user.nickname.value.contains(search)
+                        user.nickname.value.contains(search),
+                        user.isDelete.isFalse()
                 )
                 .fetchOne();
     }
 
+    private BooleanExpression userIdNe(Long loginUserId) {
+        return loginUserId == null ? null : user.id.ne(loginUserId);
+    }
+
     @Override
-    public Slice<UserSearchResponse> getCollaborators(String search, Pageable pageable, Long loginUserId) {
+    public Slice<UserSearchResponse> findAllBySearch(String search, Pageable pageable, Long loginUserId) {
         if (search.isEmpty()) {
             return new SliceImpl<>(List.of(), pageable, false);
         }
@@ -71,7 +76,8 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
                 .from(user)
                 .where(
                         userIdNe(loginUserId),
-                        user.nickname.value.contains(search)
+                        user.nickname.value.contains(search),
+                        user.isDelete.isFalse()
                 )
                 .orderBy(
                         Expressions.stringTemplate("LOCATE({0}, {1})", search, user.nickname.value).asc(),
@@ -81,9 +87,5 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
                 .offset(pageable.getOffset())
                 .fetch();
         return checkEndPage(pageable, fetch);
-    }
-
-    private BooleanExpression userIdNe(Long loginUserId) {
-        return loginUserId == null ? null : user.id.ne(loginUserId);
     }
 }


### PR DESCRIPTION
# Description
- 사용자 검색 시 탈퇴한 회원이 보이지 않도록 수정했습니다.
- 탈퇴한 회원의 리스트 상세 조회가 불가능하도록 수정헀습니다.
- 탈퇴한 회원이 콜라보레이터로 등록된 리스트를, 다른 회원의 피드에서 조회 시 나오는 버그를 해결했습니다.
- 탈퇴한 회원의 답글이 보이지 않도록 수정했습니다.
- 탈퇴한 회원이 콜렉트했던 리스트의 콜렉트 수를 감소하도록 구현했습니다.

# Relation Issues
- close #210 
