### PR TITLE
feat: 회원 탈퇴 요청 시 카카오 인증 서버에 로그아웃 요청을 보내도록 구현

### DIFF
--- a/src/main/java/com/listywave/auth/application/service/AuthService.java
+++ b/src/main/java/com/listywave/auth/application/service/AuthService.java
@@ -103,5 +103,6 @@ public class AuthService {
         List<ListEntity> lists = listRepository.findAllCollectedListBy(userId);
         lists.forEach(ListEntity::decreaseCollectCount);
 
+        kakaoOauthClient.logout(user.getKakaoAccessToken());
     }
 }

--- a/src/main/java/com/listywave/auth/presentation/AuthController.java
+++ b/src/main/java/com/listywave/auth/presentation/AuthController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -76,5 +77,11 @@ public class AuthController {
         return ResponseEntity.ok()
 //                .header(SET_COOKIE, refreshTokenCookie.toString())
                 .body(new UpdateTokenResponse(result.accessToken()));
+    }
+
+    @DeleteMapping("/withdraw")
+    ResponseEntity<Void> withdraw(@Auth Long userId) {
+        authService.withdraw(userId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -157,23 +157,6 @@ public class UserService {
         followRepository.deleteByFollowingUserAndFollowerUser(loginUser, targetUser);
     }
 
-    public void withdraw(Long userId) {
-        User user = userRepository.getById(userId);
-        user.validateUpdate(userId);
-        user.softDelete();
-
-        followRepository.getAllByFollowerUser(user).stream()
-                .map(Follow::getFollowingUser)
-                .forEach(User::decreaseFollowerCount);
-
-        followRepository.getAllByFollowingUser(user).stream()
-                .map(Follow::getFollowerUser)
-                .forEach(User::decreaseFollowingCount);
-
-        List<ListEntity> lists = listRepository.findAllCollectedListBy(userId);
-        lists.forEach(ListEntity::decreaseCollectCount);
-    }
-
     public void updateListVisibility(Long loginUserId, Long listId, Boolean beforeIsPublic) {
         User user = userRepository.getById(loginUserId);
         ListEntity list = listRepository.getById(listId);

--- a/src/main/java/com/listywave/user/presentation/UserController.java
+++ b/src/main/java/com/listywave/user/presentation/UserController.java
@@ -122,12 +122,6 @@ public class UserController {
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/withdraw")
-    ResponseEntity<Void> withdraw(@Auth Long userId) {
-        userService.withdraw(userId);
-        return ResponseEntity.noContent().build();
-    }
-
     @PatchMapping("/users/list-visibility")
     ResponseEntity<Void> updateListVisibility(
             @Auth Long loginUserId,


### PR DESCRIPTION
# Description
회원 탈퇴 요청 시 카카오 인증 서버에 로그아웃 요청을 보내도록 구현했습니다.
추가로 회원 탈퇴에 대한 메서드를 `User` 패키지에서 `Auth` 로 이동했습니다.

# Relation Issues
- close #214 