### PR TITLE
fix: cursorId를 cursorUpdatedDate로 수정

### DIFF
--- a/src/main/java/com/listywave/list/application/dto/response/ListRecentResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/ListRecentResponse.java
@@ -3,6 +3,7 @@ package com.listywave.list.application.dto.response;
 import com.listywave.list.application.domain.item.Item;
 import com.listywave.list.application.domain.label.Label;
 import com.listywave.list.application.domain.list.ListEntity;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import lombok.Builder;
@@ -10,13 +11,13 @@ import lombok.Builder;
 @Builder
 public record ListRecentResponse(
         boolean hasNext,
-        Long cursorId,
+        LocalDateTime cursorUpdatedDate,
         List<ListResponse> lists
 ) {
-    public static ListRecentResponse of(List<ListEntity> lists, Long cursorId, boolean hasNext) {
+    public static ListRecentResponse of(List<ListEntity> lists, LocalDateTime cursorUpdatedDate, boolean hasNext) {
         return ListRecentResponse.builder()
                 .hasNext(hasNext)
-                .cursorId(cursorId)
+                .cursorUpdatedDate(cursorUpdatedDate)
                 .lists(ListResponse.toList(lists))
                 .build();
     }

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -169,7 +169,7 @@ public class ListService {
     }
 
     @Transactional(readOnly = true)
-    public ListRecentResponse getRecentLists(Long loginUserId, Long cursorId, Pageable pageable) {
+    public ListRecentResponse getRecentLists(Long loginUserId, LocalDateTime cursorUpdatedDate, Pageable pageable) {
         if (loginUserId != null) {
             User user = userRepository.getById(loginUserId);
             List<Follow> follows = followRepository.getAllByFollowerUser(user);
@@ -180,21 +180,21 @@ public class ListService {
                     .toList();
 
             Slice<ListEntity> result =
-                    listRepository.getRecentListsByFollowing(myFollowingUsers, cursorId, pageable);
+                    listRepository.getRecentListsByFollowing(myFollowingUsers, cursorUpdatedDate, pageable);
             return getListRecentResponse(result);
         }
-        Slice<ListEntity> result = listRepository.getRecentLists(cursorId, pageable);
+        Slice<ListEntity> result = listRepository.getRecentLists(cursorUpdatedDate, pageable);
         return getListRecentResponse(result);
     }
 
     private ListRecentResponse getListRecentResponse(Slice<ListEntity> result) {
         List<ListEntity> recentList = result.getContent();
 
-        Long cursorId = null;
+        LocalDateTime cursorUpdatedDate = null;
         if (!recentList.isEmpty()) {
-            cursorId = recentList.get(recentList.size() - 1).getId();
+            cursorUpdatedDate = recentList.get(recentList.size() - 1).getUpdatedDate();
         }
-        return ListRecentResponse.of(recentList, cursorId, result.hasNext());
+        return ListRecentResponse.of(recentList, cursorUpdatedDate, result.hasNext());
     }
 
     public ListSearchResponse search(String keyword, SortType sortType, CategoryType category, int size, Long cursorId) {
@@ -287,20 +287,20 @@ public class ListService {
             Long targetUserId,
             String type,
             CategoryType category,
-            Long cursorId,
+            LocalDateTime cursorUpdatedDate,
             Pageable pageable
     ) {
         userRepository.getById(targetUserId);
 
         List<Collaborator> collaborators = collaboratorRepository.findAllByUserId(targetUserId);
         Slice<ListEntity> result =
-                listRepository.findFeedLists(collaborators, targetUserId, type, category, cursorId, pageable);
+                listRepository.findFeedLists(collaborators, targetUserId, type, category, cursorUpdatedDate, pageable);
         List<ListEntity> lists = result.getContent();
 
-        cursorId = null;
+        cursorUpdatedDate = null;
         if (!lists.isEmpty()) {
-            cursorId = lists.get(lists.size() - 1).getId();
+            cursorUpdatedDate = lists.get(lists.size() - 1).getUpdatedDate();
         }
-        return AllListOfUserSearchResponse.of(result.hasNext(), cursorId, lists);
+        return AllListOfUserSearchResponse.of(result.hasNext(), cursorUpdatedDate, lists);
     }
 }

--- a/src/main/java/com/listywave/list/presentation/controller/ListController.java
+++ b/src/main/java/com/listywave/list/presentation/controller/ListController.java
@@ -14,6 +14,7 @@ import com.listywave.list.presentation.dto.request.ListCreateRequest;
 import com.listywave.list.presentation.dto.request.ListUpdateRequest;
 import com.listywave.list.presentation.dto.request.ListsDeleteRequest;
 import com.listywave.user.application.dto.AllListOfUserSearchResponse;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -71,10 +72,10 @@ public class ListController {
     @GetMapping("/lists")
     ResponseEntity<ListRecentResponse> getRecentLists(
             @OptionalAuth Long loginUserId,
-            @RequestParam(name = "cursorId", required = false) Long cursorId,
+            @RequestParam(name = "cursorUpdatedDate", required = false) LocalDateTime cursorUpdatedDate,
             @PageableDefault(size = 10) Pageable pageable
     ) {
-        ListRecentResponse recentLists = listService.getRecentLists(loginUserId, cursorId, pageable);
+        ListRecentResponse recentLists = listService.getRecentLists(loginUserId, cursorUpdatedDate, pageable);
         return ResponseEntity.ok(recentLists);
     }
 
@@ -105,11 +106,11 @@ public class ListController {
             @PathVariable("userId") Long targetUserId,
             @RequestParam(name = "type", defaultValue = "my") String type,
             @RequestParam(name = "category", defaultValue = "entire") CategoryType category,
-            @RequestParam(name = "cursorId", required = false) Long cursorId,
+            @RequestParam(name = "cursorUpdatedDate", required = false) LocalDateTime cursorUpdatedDate,
             @PageableDefault(size = 10) Pageable pageable
     ) {
         AllListOfUserSearchResponse result
-                = listService.getAllListOfUser(targetUserId, type, category, cursorId, pageable);
+                = listService.getAllListOfUser(targetUserId, type, category, cursorUpdatedDate, pageable);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/com/listywave/list/repository/list/custom/CustomListRepository.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/CustomListRepository.java
@@ -4,6 +4,7 @@ import com.listywave.collaborator.application.domain.Collaborator;
 import com.listywave.list.application.domain.category.CategoryType;
 import com.listywave.list.application.domain.list.ListEntity;
 import com.listywave.user.application.domain.User;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -12,16 +13,16 @@ public interface CustomListRepository {
 
     List<ListEntity> findTrandingLists();
 
-    Slice<ListEntity> getRecentLists(Long cursorId, Pageable pageable);
+    Slice<ListEntity> getRecentLists(LocalDateTime cursorUpdatedDate, Pageable pageable);
 
-    Slice<ListEntity> getRecentListsByFollowing(List<User> followingUsers, Long cursorId, Pageable pageable);
+    Slice<ListEntity> getRecentListsByFollowing(List<User> followingUsers, LocalDateTime cursorUpdatedDate, Pageable pageable);
 
     Slice<ListEntity> findFeedLists(
             List<Collaborator> collaborators,
             Long userId,
             String type,
             CategoryType category,
-            Long cursorId,
+            LocalDateTime cursorUpdatedDate,
             Pageable pageable
     );
 

--- a/src/main/java/com/listywave/user/application/dto/AllListOfUserSearchResponse.java
+++ b/src/main/java/com/listywave/user/application/dto/AllListOfUserSearchResponse.java
@@ -2,18 +2,19 @@ package com.listywave.user.application.dto;
 
 import com.listywave.list.application.domain.item.Item;
 import com.listywave.list.application.domain.list.ListEntity;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 
 public record AllListOfUserSearchResponse(
-        Long cursorId,
+        LocalDateTime cursorUpdatedDate,
         Boolean hasNext,
         List<FeedListsResponse> feedLists
 ) {
 
-    public static AllListOfUserSearchResponse of(boolean hasNext, Long cursorId, List<ListEntity> feedLists) {
+    public static AllListOfUserSearchResponse of(boolean hasNext, LocalDateTime cursorUpdatedDate, List<ListEntity> feedLists) {
         return new AllListOfUserSearchResponse(
-                cursorId,
+                cursorUpdatedDate,
                 hasNext,
                 toList(feedLists)
         );


### PR DESCRIPTION
# Description
피드 리스트 조회, 트랜딩 리스트 조회, 최신 리스트 조회의 정렬 기준이 updatedDate의 내림차순이지만 cursor 값은 id로 인해 조회되지 않는 문제를 해결했습니다.
cursor 값을 `LocalDateTime cursorUpdatedDate`로 수정했습니다.

# 문제 현상 설명

| list_id | updatedDate |
|:--:|:--:|
| 5 | 오늘 |
| 4 | 어제 |
| 3 | 이틀전 |
| 2 | 사흘전 |
| 1 | 나흘전 |
| 6 | 닷새전 |
| 7 | 그 이상 |

위와 같이 updatedDate를 내림차순 정렬했을 때, 첫 조회 결과에서 5개만 조회한다고 가정했을 때 문제가 발생합니다.
클라이언트에서 다음 Slice를 가져오기 위해 cusorId=1을 요청에 담아 보내게 되고, 서버는 `list.id.lt(cursorId)` 비교를 통해 다음 Slice를 가져올 때 다음 데이터가 존재함에도 가져오지 못하는 문제가 발생합니다!

# 개선점

위 방법도 개선점이 필요합니다. 만약 updatedDate가 같은 리스트들이 존재한다면, 다음 Slice를 가져올 때, 같은 updatedDate는 가져오지 못하는 문제가 발생합니다.

아래는 해당 문제의 예시 상황입니다.

| list_id | updatedDate |
|:--:|:--:|
| 5 | 오늘 |
| 4 | 어제 |
| 3 | 이틀전 |
| 2 | 사흘전 |
| 1 | 나흘전 |
| 6 | 나흘전 |
| 7 | 나흘전 |

하나의 Slice에 5개를 반환한다고 가정했을 때, 클라이언트로부터 `cursorUpdateDate=나흘전`을 받게 됩니다.
그 다음 Slice를 조회할 때 id = 6, 7 번 list는 조회하지 못하는 문제가 발생합니다.

해당 문제는 발생 빈도가 낮고 급히 해결해서 개발을 완료해야하는 점을 고려하여 추후 개선하기로 결정했습니다!

# Relation Issues
- close #216 
