### PR TITLE
fix: 콜렉션 조회에서 이미지 있는 경우 가장 빠른 순위의 대표이미지 한개 가져오도록 수정

### DIFF
--- a/src/main/java/com/listywave/collection/application/dto/CollectionResponse.java
+++ b/src/main/java/com/listywave/collection/application/dto/CollectionResponse.java
@@ -45,6 +45,7 @@ public record CollectionResponse(
             Long ownerId,
             String ownerNickname,
             String ownerProfileImageUrl,
+            String representativeImageUrl,
             LocalDateTime updatedDate,
             List<ListItemsResponse> listItems
     ) {
@@ -57,6 +58,7 @@ public record CollectionResponse(
                     .ownerId(list.getUser().getId())
                     .ownerNickname(list.getUser().getNickname())
                     .ownerProfileImageUrl(list.getUser().getProfileImageUrl())
+                    .representativeImageUrl(list.getFirstItemImageUrl())
                     .updatedDate(list.getUpdatedDate())
                     .listItems(toList(list.getTop3Items().getValues()))
                     .build();


### PR DESCRIPTION
# Description
- 콜렉션 조회에서 이미지 있는 경우 가장 빠른 순위의 대표이미지 한개 가져오도록 수정하였습니다!
# Reference

# Relation Issues
- close #218 
