### PR TITLE
fix: 사용자 이미지 수정 문제 해결

### DIFF
--- a/src/main/java/com/listywave/image/application/service/ImageService.java
+++ b/src/main/java/com/listywave/image/application/service/ImageService.java
@@ -148,20 +148,20 @@ public class ImageService {
 
         if (isExistProfileExtension(profileExtension, backgroundExtension)) {
             profileImageUrl = createReadImageUrl(ImageType.USER_PROFILE, user.getId(), user.getProfileImageUrl(), profileExtension);
-            user.updateUserProfile(null, null, profileImageUrl, backgroundImageUrl);
+            user.updateUserImageUrl(profileImageUrl, backgroundImageUrl);
             isBoth = false;
         }
 
         if (isExistBackgroundExtension(backgroundExtension, profileExtension)) {
             backgroundImageUrl = createReadImageUrl(ImageType.USER_BACKGROUND, user.getId(), user.getBackgroundImageUrl(), backgroundExtension);
-            user.updateUserProfile(null, null, profileImageUrl, backgroundImageUrl);
+            user.updateUserImageUrl(profileImageUrl, backgroundImageUrl);
             isBoth = false;
         }
 
         if (isBoth) {
             profileImageUrl = createReadImageUrl(ImageType.USER_PROFILE, user.getId(), user.getProfileImageUrl(), profileExtension);
             backgroundImageUrl = createReadImageUrl(ImageType.USER_BACKGROUND, user.getId(), user.getBackgroundImageUrl(), backgroundExtension);
-            user.updateUserProfile(null, null, profileImageUrl, backgroundImageUrl);
+            user.updateUserImageUrl(profileImageUrl, backgroundImageUrl);
         }
     }
 
@@ -353,7 +353,7 @@ public class ImageService {
     }
 
     private void updateUserImageKey(User user, String profileImageKey, String backgroundImageKey) {
-        user.updateUserProfile(null, null, profileImageKey, backgroundImageKey);
+        user.updateUserImageUrl(profileImageKey, backgroundImageKey);
     }
 
     private GeneratePresignedUrlRequest createGeneratePreSignedUrlRequest(

--- a/src/main/java/com/listywave/user/application/domain/User.java
+++ b/src/main/java/com/listywave/user/application/domain/User.java
@@ -102,6 +102,19 @@ public class User extends BaseEntity {
         }
     }
 
+    public void updateUserImageUrl(String profileImage, String backgroundImage) {
+        if (!profileImage.isEmpty() && backgroundImage.isEmpty()) {
+            this.profileImageUrl = new ProfileImageUrl(profileImage);
+        }
+        if (!backgroundImage.isEmpty() && profileImage.isEmpty()) {
+            this.backgroundImageUrl = new BackgroundImageUrl(backgroundImage);
+        }
+        if (!backgroundImage.isEmpty() && !profileImage.isEmpty()) {
+            this.profileImageUrl = new ProfileImageUrl(profileImage);
+            this.backgroundImageUrl = new BackgroundImageUrl(backgroundImage);
+        }
+    }
+
     public boolean isSame(Long id) {
         return this.getId().equals(id);
     }

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -2,6 +2,7 @@ package com.listywave.user.application.service;
 
 import static com.listywave.common.exception.ErrorCode.ALREADY_FOLLOWED_EXCEPTION;
 import static com.listywave.common.exception.ErrorCode.ALREADY_NOT_FOLLOWED_EXCEPTION;
+import static com.listywave.common.exception.ErrorCode.DUPLICATE_NICKNAME_EXCEPTION;
 import static com.listywave.common.exception.ErrorCode.INVALID_ACCESS;
 
 import com.listywave.alarm.application.domain.AlarmEvent;
@@ -138,9 +139,18 @@ public class UserService {
         User targetUser = userRepository.getById(targetUserId);
 
         targetUser.validateUpdate(loginUserId);
+        String newNickname;
+        if (targetUser.getNickname().equals(command.nickname())) {
+            newNickname = null;
+        } else {
+            newNickname = command.nickname();
+            if (isDuplicateNickname(newNickname)) {
+                throw new CustomException(DUPLICATE_NICKNAME_EXCEPTION);
+            }
+        }
 
         targetUser.updateUserProfile(
-                command.nickname(),
+                newNickname,
                 command.description(),
                 command.profileImageUrl(),
                 command.backgroundImageUrl()

--- a/src/test/java/com/listywave/acceptance/user/UserAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/user/UserAcceptanceTest.java
@@ -228,21 +228,15 @@ public class UserAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        void 수정한_닉네임이_중복인_경우_400_에러가_발생한다() {
+        void 수정한_닉네임이_이미_존재하는_닉네임인_경우_400_에러가_발생한다() {
             // given
             User 동호 = 회원을_저장한다(동호());
+            User 정수 = 회원을_저장한다(정수());
             String 동호_액세스_토큰 = 액세스_토큰을_발급한다(동호);
-            UserProfileUpdateRequest 프로필_수정_요청_데이터 = 프로필_수정_요청_데이터(
-                    "사랑이형",
-                    null,
-                    null,
-                    null
-            );
-
-            프로필_수정_요청(동호_액세스_토큰, 동호.getId(), 프로필_수정_요청_데이터);
 
             // when
-            ExtractableResponse<Response> response = 프로필_수정_요청(동호_액세스_토큰, 동호.getId(), 프로필_수정_요청_데이터);
+            UserProfileUpdateRequest 닉네임_변경_요청 = 프로필_수정_요청_데이터(정수.getNickname(), null, null, null);
+            ExtractableResponse<Response> response = 프로필_수정_요청(동호_액세스_토큰, 동호.getId(), 닉네임_변경_요청);
 
             // then
             assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());

--- a/src/test/java/com/listywave/user/fixture/UserFixture.java
+++ b/src/test/java/com/listywave/user/fixture/UserFixture.java
@@ -1,5 +1,6 @@
 package com.listywave.user.fixture;
 
+import com.listywave.image.application.domain.DefaultBackgroundImages;
 import com.listywave.user.application.domain.User;
 import com.listywave.user.application.vo.BackgroundImageUrl;
 import com.listywave.user.application.vo.Description;
@@ -13,8 +14,8 @@ public class UserFixture {
                 .oauthId(2L)
                 .oauthEmail("kdkdhoho@github.com")
                 .nickname(Nickname.of("kdkdhoho"))
-                .backgroundImageUrl(new BackgroundImageUrl(""))
-                .profileImageUrl(new ProfileImageUrl(""))
+                .backgroundImageUrl(new BackgroundImageUrl(DefaultBackgroundImages.getRandomImageUrl()))
+                .profileImageUrl(new ProfileImageUrl(DefaultBackgroundImages.getRandomImageUrl()))
                 .description(new Description("동호동호"))
                 .followerCount(30)
                 .followingCount(40)
@@ -29,8 +30,8 @@ public class UserFixture {
                 .oauthId(3L)
                 .oauthEmail("pparkjs@github.com")
                 .nickname(Nickname.of("pparkjs"))
-                .backgroundImageUrl(new BackgroundImageUrl(""))
-                .profileImageUrl(new ProfileImageUrl(""))
+                .backgroundImageUrl(new BackgroundImageUrl(DefaultBackgroundImages.getRandomImageUrl()))
+                .profileImageUrl(new ProfileImageUrl(DefaultBackgroundImages.getRandomImageUrl()))
                 .description(new Description("정수정수"))
                 .followerCount(70)
                 .followingCount(80)
@@ -45,8 +46,8 @@ public class UserFixture {
                 .oauthId(4L)
                 .oauthEmail("eugene@github.com")
                 .nickname(Nickname.of("eugene"))
-                .backgroundImageUrl(new BackgroundImageUrl(""))
-                .profileImageUrl(new ProfileImageUrl(""))
+                .backgroundImageUrl(new BackgroundImageUrl(DefaultBackgroundImages.getRandomImageUrl()))
+                .profileImageUrl(new ProfileImageUrl(DefaultBackgroundImages.getRandomImageUrl()))
                 .description(new Description("유진유진"))
                 .followerCount(10)
                 .followingCount(20)


### PR DESCRIPTION
# Description
## 원인
테스트 코드 추가하면서 `User#updateProfileImageUrl` 메서드를 제거하고 `updateUserProfile`로 사용한 것이 원인이었습니다.
=> [해당 내용 확인하기](https://github.com/8-Sprinters/ListyWave-back/pull/232#discussion_r1518572720)
이미지를 수정할 때는 null이 아니라 빈 문자열로 들어가다보니 `updateUserProfile` 을 사용할 때 빈 문자열로 덮어쓰여지고 있었네요!
이 부분은 로직을 제대로 읽지 않은 제 실수입니다,,

## 해결 및 제안
일단 `updateProfileImageUrl` 복원시켜놨습니다.
그런데 `updateUserProfile` 으로만 사용하도록 `ImageService`에서 수정하지 않을 값은 null로 처리해줄 수 있을까요?
방식을 통일하고 메서드를 하나로 사용하는 걸 제안드립니다!

## Noti
추가로 dev 브랜치에 hotfix로 프로필 수정 시 닉네임 검증을 하지 않도록 수정하셨는데, 이 부분 때문에 테스트가 계속 실패했습니다!
이 부분도 수정해서 테스트 통과하도록 해결했습니다!
🚨 이제 dev에 hotfix 하기 전에 전체 테스트 한번 돌려서 확인해주세요 !! 🚨
(테스트 코드가 좋은 게 지금처럼 리팩터링 시 문제를 바로 확인할 수 있어서 좋습니다 ㅎㅎ)

# Relation Issues
- close #234 