### PR TITLE
refactor: collaborator 테이블에 ownerId를 포함하지 않도록 수정

### DIFF
--- a/src/main/java/com/listywave/collaborator/application/service/CollaboratorService.java
+++ b/src/main/java/com/listywave/collaborator/application/service/CollaboratorService.java
@@ -27,6 +27,11 @@ public class CollaboratorService {
                 .toList());
     }
 
+    @Transactional(readOnly = true, propagation = REQUIRED)
+    public Collaborators findAllByList(ListEntity list) {
+        return new Collaborators(collaboratorRepository.findAllByList(list));
+    }
+
     @Transactional(propagation = REQUIRED)
     public void saveAll(Collaborators collaborators) {
         collaboratorRepository.saveAll(collaborators.collaborators());

--- a/src/main/java/com/listywave/collaborator/application/service/CollaboratorService.java
+++ b/src/main/java/com/listywave/collaborator/application/service/CollaboratorService.java
@@ -1,0 +1,34 @@
+package com.listywave.collaborator.application.service;
+
+import static org.springframework.transaction.annotation.Propagation.REQUIRED;
+
+import com.listywave.collaborator.application.domain.Collaborator;
+import com.listywave.collaborator.application.domain.Collaborators;
+import com.listywave.collaborator.repository.CollaboratorRepository;
+import com.listywave.list.application.domain.list.ListEntity;
+import com.listywave.user.repository.user.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CollaboratorService {
+
+    private final UserRepository userRepository;
+    private final CollaboratorRepository collaboratorRepository;
+
+    @Transactional(readOnly = true, propagation = REQUIRED)
+    public Collaborators createCollaborators(List<Long> userIds, ListEntity list) {
+        return new Collaborators(userIds.stream()
+                .map(userRepository::getById)
+                .map(user -> Collaborator.init(user, list))
+                .toList());
+    }
+
+    @Transactional(propagation = REQUIRED)
+    public void saveAll(Collaborators collaborators) {
+        collaboratorRepository.saveAll(collaborators.collaborators());
+    }
+}

--- a/src/main/java/com/listywave/collaborator/application/service/CollaboratorService.java
+++ b/src/main/java/com/listywave/collaborator/application/service/CollaboratorService.java
@@ -1,6 +1,7 @@
 package com.listywave.collaborator.application.service;
 
 import static org.springframework.transaction.annotation.Propagation.REQUIRED;
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
 import com.listywave.collaborator.application.domain.Collaborator;
 import com.listywave.collaborator.application.domain.Collaborators;
@@ -19,7 +20,7 @@ public class CollaboratorService {
     private final UserRepository userRepository;
     private final CollaboratorRepository collaboratorRepository;
 
-    @Transactional(readOnly = true, propagation = REQUIRED)
+    @Transactional(readOnly = true, propagation = REQUIRES_NEW)
     public Collaborators createCollaborators(List<Long> userIds, ListEntity list) {
         return new Collaborators(userIds.stream()
                 .map(userRepository::getById)

--- a/src/main/java/com/listywave/collaborator/repository/CollaboratorRepository.java
+++ b/src/main/java/com/listywave/collaborator/repository/CollaboratorRepository.java
@@ -10,10 +10,13 @@ import org.springframework.data.repository.query.Param;
 
 public interface CollaboratorRepository extends JpaRepository<Collaborator, Long> {
 
+    @Query("""
+            select c from Collaborator  c
+            join fetch c.list l
+            join fetch c.user u
+            where c.list = :list and c.user.isDelete = false
+            """)
     List<Collaborator> findAllByList(ListEntity list);
-
-    @Query("select c from Collaborator c join fetch c.list l where c.user.id =:userId and c.user.isDelete = false")
-    List<Collaborator> findAllByUserId(Long userId);
 
     void deleteAllByList(ListEntity list);
 

--- a/src/main/java/com/listywave/history/application/service/HistoryService.java
+++ b/src/main/java/com/listywave/history/application/service/HistoryService.java
@@ -1,15 +1,19 @@
 package com.listywave.history.application.service;
 
 import static com.listywave.common.exception.ErrorCode.DELETED_USER_EXCEPTION;
+import static org.springframework.transaction.annotation.Propagation.REQUIRED;
 
 import com.listywave.common.exception.CustomException;
 import com.listywave.history.application.domain.History;
+import com.listywave.history.application.domain.HistoryItem;
 import com.listywave.history.application.dto.HistorySearchResponse;
 import com.listywave.history.repository.HistoryRepository;
+import com.listywave.list.application.domain.item.Items;
 import com.listywave.list.application.domain.list.ListEntity;
 import com.listywave.list.repository.list.ListRepository;
 import com.listywave.user.application.domain.User;
 import com.listywave.user.repository.user.UserRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -48,5 +52,13 @@ public class HistoryService {
 
         history.validateOwner(user);
         historyRepository.delete(history);
+    }
+
+    @Transactional(propagation = REQUIRED)
+    public void saveHistory(ListEntity list, LocalDateTime updatedDate, boolean isPublic) {
+        Items beforeItems = list.getItems();
+        List<HistoryItem> historyItems = beforeItems.toHistoryItems();
+        History history = new History(list, historyItems, updatedDate, isPublic);
+        historyRepository.save(history);
     }
 }

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -293,9 +293,8 @@ public class ListService {
     ) {
         userRepository.getById(targetUserId);
 
-        List<Collaborator> collaborators = collaboratorRepository.findAllByUserId(targetUserId);
         Slice<ListEntity> result =
-                listRepository.findFeedLists(collaborators, targetUserId, type, category, cursorUpdatedDate, pageable);
+                listRepository.findFeedLists(targetUserId, type, category, cursorUpdatedDate, pageable);
         List<ListEntity> lists = result.getContent();
 
         cursorUpdatedDate = null;

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -197,6 +197,7 @@ public class ListService {
         return ListRecentResponse.of(recentList, cursorUpdatedDate, result.hasNext());
     }
 
+    @Transactional(readOnly = true)
     public ListSearchResponse search(String keyword, SortType sortType, CategoryType category, int size, Long cursorId) {
         List<ListEntity> lists = listRepository.findAll().stream()
                 .filter(list -> !list.isDeletedUser() && list.isPublic())

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -45,7 +45,7 @@ import com.listywave.list.repository.list.ListRepository;
 import com.listywave.list.repository.reply.ReplyRepository;
 import com.listywave.user.application.domain.Follow;
 import com.listywave.user.application.domain.User;
-import com.listywave.user.application.dto.AllListOfUserSearchResponse;
+import com.listywave.user.application.dto.FindFeedListResponse;
 import com.listywave.user.repository.follow.FollowRepository;
 import com.listywave.user.repository.user.UserRepository;
 import java.time.LocalDateTime;
@@ -284,7 +284,7 @@ public class ListService {
     }
 
     @Transactional(readOnly = true)
-    public AllListOfUserSearchResponse getAllListOfUser(
+    public FindFeedListResponse findFeedList(
             Long targetUserId,
             String type,
             CategoryType category,
@@ -302,6 +302,6 @@ public class ListService {
         if (!lists.isEmpty()) {
             cursorUpdatedDate = lists.get(lists.size() - 1).getUpdatedDate();
         }
-        return AllListOfUserSearchResponse.of(result.hasNext(), cursorUpdatedDate, lists);
+        return FindFeedListResponse.of(result.hasNext(), cursorUpdatedDate, lists);
     }
 }

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -6,6 +6,7 @@ import static com.listywave.common.exception.ErrorCode.RESOURCES_EMPTY;
 import com.listywave.alarm.repository.AlarmRepository;
 import com.listywave.collaborator.application.domain.Collaborator;
 import com.listywave.collaborator.application.domain.Collaborators;
+import com.listywave.collaborator.application.service.CollaboratorService;
 import com.listywave.collaborator.repository.CollaboratorRepository;
 import com.listywave.collection.repository.CollectionRepository;
 import com.listywave.common.exception.CustomException;
@@ -74,6 +75,7 @@ public class ListService {
     private final CollectionRepository collectionRepository;
     private final CollaboratorRepository collaboratorRepository;
     private final AlarmRepository alarmRepository;
+    private final CollaboratorService collaboratorService;
 
     public ListCreateResponse listCreate(ListCreateRequest request, Long loginUserId) {
         User user = userRepository.getById(loginUserId);
@@ -91,11 +93,9 @@ public class ListService {
         ListEntity savedList = listRepository.save(list);
 
         if (hasCollaboration) {
-            collaboratorIds.add(user.getId());
-            Collaborators collaborators = createCollaborators(collaboratorIds, savedList);
-            collaboratorRepository.saveAll(collaborators.collaborators());
+            Collaborators collaborators = collaboratorService.createCollaborators(collaboratorIds, savedList);
+            collaboratorService.saveAll(collaborators);
         }
-
         return ListCreateResponse.of(savedList.getId());
     }
 

--- a/src/main/java/com/listywave/list/presentation/controller/ListController.java
+++ b/src/main/java/com/listywave/list/presentation/controller/ListController.java
@@ -13,7 +13,7 @@ import com.listywave.list.application.service.ListService;
 import com.listywave.list.presentation.dto.request.ListCreateRequest;
 import com.listywave.list.presentation.dto.request.ListUpdateRequest;
 import com.listywave.list.presentation.dto.request.ListsDeleteRequest;
-import com.listywave.user.application.dto.AllListOfUserSearchResponse;
+import com.listywave.user.application.dto.FindFeedListResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -102,15 +102,15 @@ public class ListController {
     }
 
     @GetMapping("/users/{userId}/lists")
-    ResponseEntity<AllListOfUserSearchResponse> getAllListOfUser(
+    ResponseEntity<FindFeedListResponse> getAllListOfUser(
             @PathVariable("userId") Long targetUserId,
             @RequestParam(name = "type", defaultValue = "my") String type,
             @RequestParam(name = "category", defaultValue = "entire") CategoryType category,
             @RequestParam(name = "cursorUpdatedDate", required = false) LocalDateTime cursorUpdatedDate,
             @PageableDefault(size = 10) Pageable pageable
     ) {
-        AllListOfUserSearchResponse result
-                = listService.getAllListOfUser(targetUserId, type, category, cursorUpdatedDate, pageable);
+        FindFeedListResponse result
+                = listService.findFeedList(targetUserId, type, category, cursorUpdatedDate, pageable);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/com/listywave/list/repository/list/custom/CustomListRepository.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/CustomListRepository.java
@@ -1,6 +1,5 @@
 package com.listywave.list.repository.list.custom;
 
-import com.listywave.collaborator.application.domain.Collaborator;
 import com.listywave.list.application.domain.category.CategoryType;
 import com.listywave.list.application.domain.list.ListEntity;
 import com.listywave.user.application.domain.User;
@@ -18,7 +17,6 @@ public interface CustomListRepository {
     Slice<ListEntity> getRecentListsByFollowing(List<User> followingUsers, LocalDateTime cursorUpdatedDate, Pageable pageable);
 
     Slice<ListEntity> findFeedLists(
-            List<Collaborator> collaborators,
             Long userId,
             String type,
             CategoryType category,

--- a/src/main/java/com/listywave/user/application/dto/FindFeedListResponse.java
+++ b/src/main/java/com/listywave/user/application/dto/FindFeedListResponse.java
@@ -6,14 +6,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 
-public record AllListOfUserSearchResponse(
+public record FindFeedListResponse(
         LocalDateTime cursorUpdatedDate,
         Boolean hasNext,
         List<FeedListInfo> feedLists
 ) {
 
-    public static AllListOfUserSearchResponse of(boolean hasNext, LocalDateTime cursorUpdatedDate, List<ListEntity> feedLists) {
-        return new AllListOfUserSearchResponse(
+    public static FindFeedListResponse of(boolean hasNext, LocalDateTime cursorUpdatedDate, List<ListEntity> feedLists) {
+        return new FindFeedListResponse(
                 cursorUpdatedDate,
                 hasNext,
                 toList(feedLists)

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -48,6 +48,7 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import com.listywave.acceptance.common.AcceptanceTest;
+import com.listywave.collaborator.application.domain.Collaborator;
 import com.listywave.history.application.dto.HistorySearchResponse;
 import com.listywave.history.application.dto.HistorySearchResponse.HistoryItemInfo;
 import com.listywave.list.application.domain.category.CategoryType;
@@ -240,17 +241,19 @@ public class ListAcceptanceTest extends AcceptanceTest {
         void 리스트를_성공적으로_수정한다() {
             // given
             User 동호 = 회원을_저장한다(동호());
+            User 정수 = 회원을_저장한다(정수());
+            User 유진 = 회원을_저장한다(유진());
             String 동호_액세스_토큰 = 액세스_토큰을_발급한다(동호);
-            ListCreateResponse 동호_리스트_생성_결과 = 리스트_저장_API_호출(좋아하는_견종_TOP3_생성_요청_데이터(List.of()), 동호_액세스_토큰).as(ListCreateResponse.class);
+            ListCreateResponse 동호_리스트_생성_결과 = 리스트_저장_API_호출(좋아하는_견종_TOP3_생성_요청_데이터(List.of(정수.getId())), 동호_액세스_토큰).as(ListCreateResponse.class);
 
             // when
-            ListCreateRequest 리스트_수정_요청_데이터 = 아이템_순위와_라벨이_바뀐_좋아하는_견종_TOP3_요청_데이터(List.of());
+            ListCreateRequest 리스트_수정_요청_데이터 = 아이템_순위와_라벨이_바뀐_좋아하는_견종_TOP3_요청_데이터(List.of(유진.getId()));
             리스트_수정_API_호출(리스트_수정_요청_데이터, 동호_액세스_토큰, 동호_리스트_생성_결과.listId());
 
             // then
             ListDetailResponse result = 회원용_리스트_상세_조회_API_호출(동호_액세스_토큰, 동호_리스트_생성_결과.listId());
             ListEntity 수정된_리스트 = 가장_좋아하는_견종_TOP3_순위_변경(동호, List.of());
-            ListDetailResponse expect = ListDetailResponse.of(수정된_리스트, 동호, false, List.of(), 수정된_리스트.getSortedItems().getValues());
+            ListDetailResponse expect = ListDetailResponse.of(수정된_리스트, 동호, false, List.of(Collaborator.init(유진, 수정된_리스트)), 수정된_리스트.getSortedItems().getValues());
             리스트_상세_조회를_검증한다(result, expect);
         }
 

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -99,6 +99,24 @@ public class ListAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
+        void 콜라보레이터를_지정해_리스트를_생성할_수_있다() {
+            // given
+            User 동호 = 회원을_저장한다(동호());
+            User 정수 = 회원을_저장한다(정수());
+            String accessToken = 액세스_토큰을_발급한다(동호);
+            ListCreateRequest listCreateRequest = 좋아하는_견종_TOP3_생성_요청_데이터(List.of(정수.getId()));
+
+            // when
+            ExtractableResponse<Response> response = 리스트_저장_API_호출(listCreateRequest, accessToken);
+            ListCreateResponse result = response.as(ListCreateResponse.class);
+
+            // then
+            assertThat(result.listId()).isEqualTo(1L);
+            ListDetailResponse list = 비회원_리스트_상세_조회_API_호출(result.listId()).as(ListDetailResponse.class);
+            assertThat(list.collaborators().get(0).id()).isEqualTo(정수.getId());
+        }
+
+        @Test
         void 인증_정보가_없으면_401_에러가_발생한다() {
             // given
             ListCreateRequest listCreateRequest = 좋아하는_견종_TOP3_생성_요청_데이터(List.of());

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -60,9 +60,9 @@ import com.listywave.list.application.dto.response.ListSearchResponse;
 import com.listywave.list.application.dto.response.ListTrandingResponse;
 import com.listywave.list.presentation.dto.request.ListCreateRequest;
 import com.listywave.user.application.domain.User;
-import com.listywave.user.application.dto.AllListOfUserSearchResponse;
-import com.listywave.user.application.dto.AllListOfUserSearchResponse.FeedListInfo;
-import com.listywave.user.application.dto.AllListOfUserSearchResponse.ListItemsResponse;
+import com.listywave.user.application.dto.FindFeedListResponse;
+import com.listywave.user.application.dto.FindFeedListResponse.FeedListInfo;
+import com.listywave.user.application.dto.FindFeedListResponse.ListItemsResponse;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -360,7 +360,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
             ListEntity 동호_리스트_2 = 리스트를_저장한다(좋아하는_라면_TOP3(동호, List.of()));
 
             // when
-            AllListOfUserSearchResponse result = 비회원_피드_리스트_조회(동호).as(AllListOfUserSearchResponse.class);
+            FindFeedListResponse result = 비회원_피드_리스트_조회(동호).as(FindFeedListResponse.class);
 
             // then
             assertThat(result.hasNext()).isFalse();
@@ -389,7 +389,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
             String 정수_액세스_토큰 = 액세스_토큰을_발급한다(정수);
 
             // when
-            AllListOfUserSearchResponse allUserListsResponse = 회원_피드_리스트_조회(동호, 정수_액세스_토큰).as(AllListOfUserSearchResponse.class);
+            FindFeedListResponse allUserListsResponse = 회원_피드_리스트_조회(동호, 정수_액세스_토큰).as(FindFeedListResponse.class);
 
             // then
             assertAll(
@@ -420,7 +420,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
             리스트를_모두_저장한다(동호_리스트들);
 
             // when
-            AllListOfUserSearchResponse result = 비회원이_피드_리스트_조회_카테고리_필터링_요청(동호, "book").as(AllListOfUserSearchResponse.class);
+            FindFeedListResponse result = 비회원이_피드_리스트_조회_카테고리_필터링_요청(동호, "book").as(FindFeedListResponse.class);
 
             // then
             CategoryType 필터링_조건 = CategoryType.nameOf("book");
@@ -446,7 +446,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
             Long 리스트_2_ID = 리스트_저장_API_호출(좋아하는_견종_TOP3_생성_요청_데이터(List.of(동호.getId())), 정수_액세스_토큰).as(ListCreateResponse.class).listId();
 
             // when
-            AllListOfUserSearchResponse result = 비회원이_피드_리스트_조회_콜라보레이터_필터링_요청(동호).as(AllListOfUserSearchResponse.class);
+            FindFeedListResponse result = 비회원이_피드_리스트_조회_콜라보레이터_필터링_요청(동호).as(FindFeedListResponse.class);
 
             // then
             assertThat(result.feedLists()).hasSize(2);
@@ -464,7 +464,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
             ListCreateResponse 동호_리스트_2 = 리스트_저장_API_호출(좋아하는_라면_TOP3_생성_요청_데이터(List.of(정수.getId())), 동호_액세스_토큰).as(ListCreateResponse.class);
 
             // when
-            AllListOfUserSearchResponse result = 비회원이_피드_리스트_조회_카테고리_콜라보레이터_필터링_요청(동호, "etc").as(AllListOfUserSearchResponse.class);
+            FindFeedListResponse result = 비회원이_피드_리스트_조회_카테고리_콜라보레이터_필터링_요청(동호, "etc").as(FindFeedListResponse.class);
 
             // then
             assertThat(result.feedLists()).hasSize(1);
@@ -490,8 +490,8 @@ public class ListAcceptanceTest extends AcceptanceTest {
             });
 
             // then
-            List<FeedListInfo> 동호_리스트 = 비회원_피드_리스트_조회(동호).as(AllListOfUserSearchResponse.class).feedLists();
-            List<FeedListInfo> 정수_리스트 = 비회원_피드_리스트_조회(정수).as(AllListOfUserSearchResponse.class).feedLists();
+            List<FeedListInfo> 동호_리스트 = 비회원_피드_리스트_조회(동호).as(FindFeedListResponse.class).feedLists();
+            List<FeedListInfo> 정수_리스트 = 비회원_피드_리스트_조회(정수).as(FindFeedListResponse.class).feedLists();
             List<FeedListInfo> 모든_리스트 = new ArrayList<>(동호_리스트);
             모든_리스트.addAll(정수_리스트);
 
@@ -550,8 +550,8 @@ public class ListAcceptanceTest extends AcceptanceTest {
             ListRecentResponse result = response.as(ListRecentResponse.class);
 
             // then
-            List<FeedListInfo> 동호_리스트 = 비회원_피드_리스트_조회(동호).as(AllListOfUserSearchResponse.class).feedLists();
-            List<FeedListInfo> 정수_리스트 = 비회원_피드_리스트_조회(정수).as(AllListOfUserSearchResponse.class).feedLists();
+            List<FeedListInfo> 동호_리스트 = 비회원_피드_리스트_조회(동호).as(FindFeedListResponse.class).feedLists();
+            List<FeedListInfo> 정수_리스트 = 비회원_피드_리스트_조회(정수).as(FindFeedListResponse.class).feedLists();
             List<FeedListInfo> 모든_리스트 = new ArrayList<>(동호_리스트);
             모든_리스트.addAll(정수_리스트);
             List<Long> expect = 모든_리스트.stream()

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -423,16 +423,17 @@ public class ListAcceptanceTest extends AcceptanceTest {
             User 동호 = 회원을_저장한다(동호());
             User 정수 = 회원을_저장한다(정수());
             String 동호_액세스_토큰 = 액세스_토큰을_발급한다(동호);
-            액세스_토큰을_발급한다(정수);
-            리스트_저장_API_호출(좋아하는_견종_TOP3_생성_요청_데이터(List.of()), 동호_액세스_토큰).as(ListCreateResponse.class);
-            ListCreateResponse 동호_리스트_2 = 리스트_저장_API_호출(좋아하는_라면_TOP3_생성_요청_데이터(List.of(정수.getId())), 동호_액세스_토큰).as(ListCreateResponse.class);
+            String 정수_액세스_토큰 = 액세스_토큰을_발급한다(정수);
+            Long 리스트_1_ID = 리스트_저장_API_호출(좋아하는_견종_TOP3_생성_요청_데이터(List.of(정수.getId())), 동호_액세스_토큰).as(ListCreateResponse.class).listId();
+            Long 리스트_2_ID = 리스트_저장_API_호출(좋아하는_견종_TOP3_생성_요청_데이터(List.of(동호.getId())), 정수_액세스_토큰).as(ListCreateResponse.class).listId();
 
             // when
             AllListOfUserSearchResponse result = 비회원이_피드_리스트_조회_콜라보레이터_필터링_요청(동호).as(AllListOfUserSearchResponse.class);
 
             // then
-            assertThat(result.feedLists()).hasSize(1);
-            assertThat(result.feedLists().get(0).id()).isEqualTo(동호_리스트_2.listId());
+            assertThat(result.feedLists()).hasSize(2);
+            assertThat(result.feedLists().get(0).id()).isEqualTo(리스트_2_ID);
+            assertThat(result.feedLists().get(1).id()).isEqualTo(리스트_1_ID);
         }
 
         @Test

--- a/src/test/java/com/listywave/list/application/domain/list/ListEntityTest.java
+++ b/src/test/java/com/listywave/list/application/domain/list/ListEntityTest.java
@@ -11,6 +11,7 @@ import static com.listywave.user.fixture.UserFixture.유진;
 import static com.listywave.user.fixture.UserFixture.정수;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.listywave.collaborator.application.domain.Collaborator;
@@ -224,17 +225,22 @@ class ListEntityTest {
 
     @Test
     void 리스트는_작성자_또는_콜라보레이터에_포함된_유저만이_수정할_수_있다() {
-        User collaborator = 정수();
+        // given
+        User collaboratorUser = 정수();
+        Collaborator collaborator = Collaborator.init(collaboratorUser, list);
         User notCollaborator = 유진();
 
-        Collaborators collaborators = new Collaborators(List.of(
-                Collaborator.init(collaborator, list)
-        ));
+        Collaborators collaborators = new Collaborators(List.of(collaborator));
 
-        assertThatNoException().isThrownBy(() -> list.validateUpdateAuthority(user, collaborators));
-        assertThatNoException().isThrownBy(() -> list.validateUpdateAuthority(collaborator, collaborators));
-
-        CustomException exception = assertThrows(CustomException.class, () -> list.validateUpdateAuthority(notCollaborator, collaborators));
-        assertThat(exception.getErrorCode()).isEqualTo(INVALID_ACCESS);
+        // when
+        // then
+        assertAll(
+                () -> assertThatNoException().isThrownBy(() -> list.validateUpdateAuthority(user, collaborators)),
+                () -> assertThatNoException().isThrownBy(() -> list.validateUpdateAuthority(collaboratorUser, collaborators)),
+                () -> {
+                    CustomException exception = assertThrows(CustomException.class, () -> list.validateUpdateAuthority(notCollaborator, collaborators));
+                    assertThat(exception.getErrorCode()).isEqualTo(INVALID_ACCESS);
+                }
+        );
     }
 }


### PR DESCRIPTION
# Description
## 수정한 이유
현재 리스트 수정 시, 생길 수 있는 동시성 문제를 해결하기 위해 여러 테스트를 진행 중입니다.
하지만 collaborator 테이블에 ownerId가 포함되어, 리스트 수정 로직이 굉장히 복잡해지고 많은 버그가 생겨 이를 개선했습니다.

## 주요 수정 내용
- [x] 리스트 생성 시, collaborators에 본인을 포함하지 않습니다.
- [x] 피드에서 콜라보 리스트 조회 시, 본인이 작성한 콜라보 리스트 및 콜라보레이터로 포함된 리스트를 모두 응답합니다.
- [x] 리스트 수정 시, 요청 데이터의 collaboratorIds 필드에 더 이상 ownerId를 포함하지 않습니다.
  - [x] 수정 단계에서 collaborator를 저장할 때에도 ownerId를 포함하지 않습니다.

# 🚨 Caution
## ~~최대한 프론트엔드와 동시에 머지해주세요!~~

## Merge가 되는 대로 collaborator 테이블에 ownerId가 포함된 Row를 제거해야 합니다.
아래 쿼리를 실행해주세요!
```sql
delete from collaborator c
where c.user_id IN (SELECT * FROM list l WHERE l.owner_id = c.user_id);
```

# Relation Issues
- close #236 
