### PR TITLE
feat: 리스트 생성 시 히스토리로도 저장되도록 구현

### DIFF
--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -92,6 +92,8 @@ public class ListService {
                 request.backgroundColor(), hasCollaboration, labels, items);
         ListEntity savedList = listRepository.save(list);
 
+        historyService.saveHistory(savedList, LocalDateTime.now(), true);
+
         if (hasCollaboration) {
             Collaborators collaborators = collaboratorService.createCollaborators(collaboratorIds, savedList);
             collaboratorService.saveAll(collaborators);

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -72,13 +72,9 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @DisplayName("리스트 관련 인수테스트")
 public class ListAcceptanceTest extends AcceptanceTest {
-
-    private static final Logger log = LoggerFactory.getLogger(ListAcceptanceTest.class);
 
     @Nested
     class 리스트_생성 {
@@ -131,6 +127,27 @@ public class ListAcceptanceTest extends AcceptanceTest {
 
             // then
             assertThat(response.statusCode()).isEqualTo(UNAUTHORIZED.value());
+        }
+
+        @Test
+        void 리스트_생성_시_히스토리도_함께_생성된다() {
+            // given
+            User 동호 = 회원을_저장한다(동호());
+            String accessToken = 액세스_토큰을_발급한다(동호);
+            ListCreateRequest listCreateRequest = 좋아하는_견종_TOP3_생성_요청_데이터(List.of());
+
+            ListCreateResponse 리스트_저장_API_응답 = 리스트_저장_API_호출(listCreateRequest, accessToken).as(ListCreateResponse.class);
+            Long 생성된_리스트_ID = 리스트_저장_API_응답.listId();
+
+            // when
+            List<HistorySearchResponse> 비회원_히스토리_조회_API_응답 = 비회원_히스토리_조회_API_호출(생성된_리스트_ID);
+
+            // then
+            HistorySearchResponse 첫_히스토리 = 비회원_히스토리_조회_API_응답.get(0);
+            assertThat(첫_히스토리.isPublic()).isTrue();
+            assertThat(첫_히스토리.items()).usingRecursiveComparison()
+                    .comparingOnlyFields("rank", "title")
+                    .isEqualTo(listCreateRequest.items());
         }
     }
 

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -268,7 +268,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
             리스트_수정_API_호출(리스트_수정_요청_데이터, 동호_액세스_토큰, 동호_리스트.getId());
 
             // when
-            List<HistorySearchResponse> 히스토리_조회_결과 = 비회원_히스토리_조회_API_호출(동호_리스트);
+            List<HistorySearchResponse> 히스토리_조회_결과 = 비회원_히스토리_조회_API_호출(동호_리스트.getId());
             ListDetailResponse 수정된_리스트_상세_조회_결과 = 비회원_리스트_상세_조회_API_호출(동호_리스트.getId()).as(ListDetailResponse.class);
 
             // then

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTestHelper.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTestHelper.java
@@ -113,9 +113,9 @@ public abstract class ListAcceptanceTestHelper {
                 .isEqualTo(expect);
     }
 
-    public static List<HistorySearchResponse> 비회원_히스토리_조회_API_호출(ListEntity list) {
+    public static List<HistorySearchResponse> 비회원_히스토리_조회_API_호출(Long listId) {
         var response = given()
-                .when().get("/lists/{listId}/histories", list.getId())
+                .when().get("/lists/{listId}/histories", listId)
                 .then().log().all()
                 .extract();
         return response.as(new TypeRef<>() {


### PR DESCRIPTION
# Description
리스트 생성 시, 히스토리로도 함께 저장되도록 구현했습니다.
이전에 만들어 둔 `HistoryService#saveHistory` 메서드를 재사용해서 코드 한 줄만 추가해 구현했습니다!
이에 대한 테스트 코드 작성과 정상 동작 또한 확인했습니다.

> ps) 오랜만에 개발하니 조금 낯서네요 ㅋㅋㅋ

# Relation Issues
- close #242 
