### PR TITLE
fix: 리스트 상세 조회 시, isCollected가 항상 false로 반환되는 버그 해결

### DIFF
--- a/src/main/java/com/listywave/common/auth/AuthorizationInterceptor.java
+++ b/src/main/java/com/listywave/common/auth/AuthorizationInterceptor.java
@@ -18,7 +18,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class AuthorizationInterceptor implements HandlerInterceptor {
 
     private static final UriAndMethod[] whiteList = {
-            new UriAndMethod("/lists/{listId}", GET),
             new UriAndMethod("/lists/explore", GET),
             new UriAndMethod("/lists/search", GET),
             new UriAndMethod("/lists/{listId}/comments", GET),
@@ -40,7 +39,7 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
     private final TokenReader tokenReader;
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         if (isPreflight(request)) {
             return true;
         }

--- a/src/main/java/com/listywave/list/application/dto/response/ListDetailResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/ListDetailResponse.java
@@ -33,8 +33,7 @@ public record ListDetailResponse(
             ListEntity list,
             User owner,
             boolean isCollected,
-            List<Collaborator> collaborators,
-            List<Item> items
+            List<Collaborator> collaborators
     ) {
         return ListDetailResponse.builder()
                 .category(list.getCategory().getViewName())

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -128,14 +128,13 @@ public class ListService {
         ListEntity list = listRepository.getById(listId);
         list.validateOwnerIsNotDelete();
         List<Collaborator> collaborators = collaboratorRepository.findAllByList(list);
-        Items sortedItems = list.getSortedItems();
 
         boolean isCollected = false;
         if (loginUserId != null) {
             User user = userRepository.getById(loginUserId);
             isCollected = collectionRepository.existsByListAndUserId(list, user.getId());
         }
-        return ListDetailResponse.of(list, list.getUser(), isCollected, collaborators, sortedItems.getValues());
+        return ListDetailResponse.of(list, list.getUser(), isCollected, collaborators);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -166,7 +166,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
             ListDetailResponse result = response.as(ListDetailResponse.class);
 
             // then
-            ListDetailResponse expect = ListDetailResponse.of(동호_리스트, 동호, false, List.of(), 동호_리스트.getSortedItems().getValues());
+            ListDetailResponse expect = ListDetailResponse.of(동호_리스트, 동호, false, List.of());
             리스트_상세_조회를_검증한다(result, expect);
         }
 
@@ -187,8 +187,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
                     동호_리스트,
                     동호,
                     collectionRepository.existsByListAndUserId(동호_리스트, 정수.getId()),
-                    collaboratorRepository.findAllByList(동호_리스트),
-                    동호_리스트.getSortedItems().getValues()
+                    collaboratorRepository.findAllByList(동호_리스트)
             );
             리스트_상세_조회를_검증한다(result, expect);
         }
@@ -210,8 +209,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
                     동호_리스트,
                     동호,
                     false,
-                    collaboratorRepository.findAllByList(동호_리스트),
-                    동호_리스트.getSortedItems().getValues()
+                    collaboratorRepository.findAllByList(동호_리스트)
             );
             리스트_상세_조회를_검증한다(result, expect);
         }
@@ -232,7 +230,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
 
             // then
             ListEntity 바뀐_리스트 = 가장_좋아하는_견종_TOP3_순위_변경(동호, List.of());
-            ListDetailResponse expect = ListDetailResponse.of(바뀐_리스트, 동호, false, List.of(), 바뀐_리스트.getSortedItems().getValues());
+            ListDetailResponse expect = ListDetailResponse.of(바뀐_리스트, 동호, false, List.of());
             리스트_상세_조회를_검증한다(result, expect);
         }
 
@@ -271,7 +269,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
             // then
             ListDetailResponse result = 회원용_리스트_상세_조회_API_호출(동호_액세스_토큰, 동호_리스트_생성_결과.listId());
             ListEntity 수정된_리스트 = 가장_좋아하는_견종_TOP3_순위_변경(동호, List.of());
-            ListDetailResponse expect = ListDetailResponse.of(수정된_리스트, 동호, false, List.of(Collaborator.init(유진, 수정된_리스트)), 수정된_리스트.getSortedItems().getValues());
+            ListDetailResponse expect = ListDetailResponse.of(수정된_리스트, 동호, false, List.of(Collaborator.init(유진, 수정된_리스트)));
             리스트_상세_조회를_검증한다(result, expect);
         }
 


### PR DESCRIPTION
# Description
이전에 `OptionalAuthArgumentResolver`에 있는 로직이 `AuthenticationInterceptor`의 로직과 중복된 부분을 리팩터링 하는 과정에서`@OptionalAuth`로 처리되는 API를 whiteList에서 제거해야 했습니다.
하지만 리스트 상세 조회 API가 포함되어 있어 항상 비인증 상태로 처리되던 것이 원인이었습니다.

콜렉트 관련 테스트가 없어 놓쳐버렸네요! 해당 부분 테스트는 정수씌한테 맡겼는데 언제쯤 해주실 예정이신가용?

# Relation Issues
- close #246 