### PR TITLE
 feat: 나의 모든 알림 읽기 API 구현

### DIFF
--- a/src/main/java/com/listywave/alarm/application/service/AlarmService.java
+++ b/src/main/java/com/listywave/alarm/application/service/AlarmService.java
@@ -10,7 +10,6 @@ import com.listywave.alarm.repository.AlarmRepository;
 import com.listywave.common.exception.CustomException;
 import com.listywave.user.application.domain.User;
 import com.listywave.user.repository.user.UserRepository;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -50,7 +49,6 @@ public class AlarmService {
 
     public void readAllAlarm(Long loginUserId) {
         User user = userRepository.getById(loginUserId);
-        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
-        alarmRepository.readAllAlarm(user.getId(), thirtyDaysAgo);
+        alarmRepository.readAllAlarm(user.getId());
     }
 }

--- a/src/main/java/com/listywave/alarm/application/service/AlarmService.java
+++ b/src/main/java/com/listywave/alarm/application/service/AlarmService.java
@@ -10,6 +10,7 @@ import com.listywave.alarm.repository.AlarmRepository;
 import com.listywave.common.exception.CustomException;
 import com.listywave.user.application.domain.User;
 import com.listywave.user.repository.user.UserRepository;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -45,5 +46,11 @@ public class AlarmService {
     public AlarmCheckResponse checkAllAlarmsRead(Long loginUserId) {
         User user = userRepository.getById(loginUserId);
         return new AlarmCheckResponse(alarmRepository.hasCheckedAlarmsByReceiveUserId(user.getId()));
+    }
+
+    public void readAllAlarm(Long loginUserId) {
+        User user = userRepository.getById(loginUserId);
+        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+        alarmRepository.readAllAlarm(user.getId(), thirtyDaysAgo);
     }
 }

--- a/src/main/java/com/listywave/alarm/presentation/controller/AlarmController.java
+++ b/src/main/java/com/listywave/alarm/presentation/controller/AlarmController.java
@@ -40,4 +40,12 @@ public class AlarmController {
     ) {
         return ResponseEntity.ok().body(alarmService.checkAllAlarmsRead(loginUserId));
     }
+
+    @PatchMapping("/alarms")
+    ResponseEntity<Void> readAllAlarm(
+            @Auth Long loginUserId
+    ) {
+        alarmService.readAllAlarm(loginUserId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/listywave/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/listywave/alarm/repository/AlarmRepository.java
@@ -2,6 +2,7 @@ package com.listywave.alarm.repository;
 
 import com.listywave.alarm.application.domain.Alarm;
 import com.listywave.alarm.repository.custom.CustomAlarmRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -25,4 +26,14 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long>, CustomAlarm
     @Modifying
     @Query("delete from Alarm a where a.listId in :listIds")
     void deleteAllByListIdIn(@Param("listIds") List<Long> listIds);
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            update Alarm a
+            set a.isChecked = true
+            where a.receiveUserId = :receiveUserId
+            and a.isChecked = false
+            and a.createdDate >= :thirtyDaysAgo
+            """)
+    void readAllAlarm(Long receiveUserId, LocalDateTime thirtyDaysAgo);
 }

--- a/src/main/java/com/listywave/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/listywave/alarm/repository/AlarmRepository.java
@@ -2,7 +2,6 @@ package com.listywave.alarm.repository;
 
 import com.listywave.alarm.application.domain.Alarm;
 import com.listywave.alarm.repository.custom.CustomAlarmRepository;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -33,7 +32,6 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long>, CustomAlarm
             set a.isChecked = true
             where a.receiveUserId = :receiveUserId
             and a.isChecked = false
-            and a.createdDate >= :thirtyDaysAgo
             """)
-    void readAllAlarm(Long receiveUserId, LocalDateTime thirtyDaysAgo);
+    void readAllAlarm(Long receiveUserId);
 }

--- a/src/test/java/com/listywave/acceptance/alarm/AlarmAcceptanceTestHelper.java
+++ b/src/test/java/com/listywave/acceptance/alarm/AlarmAcceptanceTestHelper.java
@@ -23,4 +23,12 @@ public abstract class AlarmAcceptanceTestHelper {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 알람_전체_읽기_API_호출(String accessToken) {
+        return given()
+                .header(AUTHORIZATION, "Bearer " + accessToken)
+                .when().patch("/alarms")
+                .then().log().all()
+                .extract();
+    }
 }


### PR DESCRIPTION
# Description
- 나에게 온 알람을 일괄로 읽을 수 있는 API를 구현하였습니다.
- JPA 영속성 컨텍스트에서 더티체킹으로 업데이트 하게 되는 경우 알림이 많은 경우 성능에 문제가 발생할 우려가 생기므로 벌크성 업데이트를 이용하였습니다.

# Reference
https://yarisong.tistory.com/38
# Relation Issues
- close #241 
