### PR TITLE
feat: 리스트의 배경색을 HexCode에서 이름으로 대체하고 backgroundPalette 필드를 추가한다

### DIFF
--- a/src/main/java/com/listywave/collection/application/dto/CollectionResponse.java
+++ b/src/main/java/com/listywave/collection/application/dto/CollectionResponse.java
@@ -53,7 +53,7 @@ public record CollectionResponse(
         public static ListsResponse of(ListEntity list) {
             return ListsResponse.builder()
                     .id(list.getId())
-                    .backgroundColor(list.getBackgroundColor())
+                    .backgroundColor(list.getBackgroundColor().name())
                     .title(list.getTitle().getValue())
                     .ownerId(list.getUser().getId())
                     .ownerNickname(list.getUser().getNickname())

--- a/src/main/java/com/listywave/list/application/domain/list/BackgroundColor.java
+++ b/src/main/java/com/listywave/list/application/domain/list/BackgroundColor.java
@@ -1,0 +1,29 @@
+package com.listywave.list.application.domain.list;
+
+public enum BackgroundColor {
+
+    PASTEL_PINK,
+    PASTEL_ORANGE,
+    PASTEL_YELLOW,
+    PASTEL_GREEN,
+    PASTEL_SKYBLUE,
+    PASTEL_PURPLE,
+
+    VIVID_RED,
+    VIVID_ORANGE,
+    VIVID_YELLOW,
+    VIVID_GREEN,
+    VIVID_BLUE,
+    VIVID_PURPLE,
+
+    GRAY_VERYLIGHT,
+    GRAY_LIGHT,
+    GRAY_MEDIUM,
+
+    LISTY_WHITE,
+    LISTY_YELLOW,
+    LISTY_ORANGE,
+    LISTY_GREEN,
+    LISTY_BLUE,
+    LISTY_PURPLE,
+}

--- a/src/main/java/com/listywave/list/application/domain/list/BackgroundPalette.java
+++ b/src/main/java/com/listywave/list/application/domain/list/BackgroundPalette.java
@@ -1,0 +1,9 @@
+package com.listywave.list.application.domain.list;
+
+public enum BackgroundPalette {
+
+    PASTEL,
+    VIVID,
+    GRAY,
+    LISTY,
+}

--- a/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
+++ b/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
@@ -22,6 +22,8 @@ import jakarta.persistence.Convert;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -67,7 +69,12 @@ public class ListEntity {
     private boolean isPublic;
 
     @Column(nullable = false)
-    private String backgroundColor;
+    @Enumerated(value = EnumType.STRING)
+    private BackgroundPalette backgroundPalette;
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private BackgroundColor backgroundColor;
 
     @Column(nullable = false)
     private boolean hasCollaboration;
@@ -93,16 +100,23 @@ public class ListEntity {
     private LocalDateTime updatedDate;
 
     public ListEntity(
-            User user, CategoryType category, ListTitle title,
-            ListDescription description, boolean isPublic,
-            String backgroundColor, boolean hasCollaboration,
-            Labels labels, Items items
+            User user,
+            CategoryType category,
+            ListTitle title,
+            ListDescription description,
+            boolean isPublic,
+            BackgroundPalette backgroundPalette,
+            BackgroundColor backgroundColor,
+            boolean hasCollaboration,
+            Labels labels,
+            Items items
     ) {
         this.user = user;
         this.category = category;
         this.title = title;
         this.description = description;
         this.isPublic = isPublic;
+        this.backgroundPalette = backgroundPalette;
         this.backgroundColor = backgroundColor;
         this.hasCollaboration = hasCollaboration;
         this.labels = labels.updateList(this);
@@ -182,7 +196,8 @@ public class ListEntity {
             ListTitle title,
             ListDescription description,
             boolean isPublic,
-            String backgroundColor,
+            BackgroundPalette backgroundPalette,
+            BackgroundColor backgroundColor,
             boolean hasCollaboration,
             LocalDateTime updatedDate,
             Labels newLabels,
@@ -192,6 +207,7 @@ public class ListEntity {
         this.title = title;
         this.description = description;
         this.isPublic = isPublic;
+        this.backgroundPalette = backgroundPalette;
         this.backgroundColor = backgroundColor;
         this.hasCollaboration = hasCollaboration;
         this.updatedDate = updatedDate;

--- a/src/main/java/com/listywave/list/application/dto/response/ListDetailResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/ListDetailResponse.java
@@ -24,6 +24,7 @@ public record ListDetailResponse(
         List<ItemResponse> items,
         boolean isCollected,
         boolean isPublic,
+        String backgroundPalette,
         String backgroundColor,
         int collectCount,
         int viewCount
@@ -49,7 +50,8 @@ public record ListDetailResponse(
                 .items(ItemResponse.toList(list.getSortedItems().getValues()))
                 .isCollected(isCollected)
                 .isPublic(list.isPublic())
-                .backgroundColor(list.getBackgroundColor())
+                .backgroundColor(list.getBackgroundColor().name())
+                .backgroundPalette(list.getBackgroundPalette().name())
                 .collectCount(list.getCollectCount())
                 .viewCount(list.getViewCount())
                 .build();

--- a/src/main/java/com/listywave/list/application/dto/response/ListRecentResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/ListRecentResponse.java
@@ -46,7 +46,7 @@ public record ListRecentResponse(
             return ListResponse.builder()
                     .id(list.getId())
                     .category(list.getCategory().getViewName())
-                    .backgroundColor(list.getBackgroundColor())
+                    .backgroundColor(list.getBackgroundColor().name())
                     .ownerId(list.getUser().getId())
                     .ownerNickname(list.getUser().getNickname())
                     .ownerProfileImage(list.getUser().getProfileImageUrl())

--- a/src/main/java/com/listywave/list/application/dto/response/ListSearchResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/ListSearchResponse.java
@@ -54,7 +54,7 @@ public record ListSearchResponse(
                     .title(list.getTitle().getValue())
                     .items(ItemInfo.toList(list.getTop3Items().getValues()))
                     .isPublic(list.isPublic())
-                    .backgroundColor(list.getBackgroundColor())
+                    .backgroundColor(list.getBackgroundColor().name())
                     .updatedDate(list.getUpdatedDate())
                     .ownerId(list.getUser().getId())
                     .ownerNickname(list.getUser().getNickname())

--- a/src/main/java/com/listywave/list/application/dto/response/ListTrandingResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/ListTrandingResponse.java
@@ -24,7 +24,7 @@ public record ListTrandingResponse(
                 .title(list.getTitle().getValue())
                 .description(list.getDescription().getValue())
                 .itemImageUrl(list.getRepresentImageUrl())
-                .backgroundColor(list.getBackgroundColor())
+                .backgroundColor(list.getBackgroundColor().name())
                 .build();
     }
 }

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -90,9 +90,18 @@ public class ListService {
         Labels labels = createLabels(request.labels());
         Items items = createItems(request.items());
 
-        ListEntity list = new ListEntity(user, request.category(), new ListTitle(request.title()),
-                new ListDescription(request.description()), request.isPublic(),
-                request.backgroundColor(), hasCollaboration, labels, items);
+        ListEntity list = new ListEntity(
+                user,
+                request.category(),
+                new ListTitle(request.title()),
+                new ListDescription(request.description()),
+                request.isPublic(),
+                request.backgroundPalette(),
+                request.backgroundColor(),
+                hasCollaboration,
+                labels,
+                items
+        );
         ListEntity savedList = listRepository.save(list);
 
         historyService.saveHistory(savedList, LocalDateTime.now(), true);
@@ -237,7 +246,18 @@ public class ListService {
             historyService.saveHistory(list, updatedDate, request.isPublic());
         }
         boolean hasCollaborator = !request.collaboratorIds().isEmpty();
-        list.update(request.category(), new ListTitle(request.title()), new ListDescription(request.description()), request.isPublic(), request.backgroundColor(), hasCollaborator, updatedDate, newLabels, newItems);
+        list.update(
+                request.category(),
+                new ListTitle(request.title()),
+                new ListDescription(request.description()),
+                request.isPublic(),
+                request.backgroundPalette(),
+                request.backgroundColor(),
+                hasCollaborator,
+                updatedDate,
+                newLabels,
+                newItems
+        );
     }
 
     private void updateCollaborators(Collaborators beforeCollaborators, Collaborators newCollaborators, ListEntity list) {

--- a/src/main/java/com/listywave/list/presentation/dto/request/ListCreateRequest.java
+++ b/src/main/java/com/listywave/list/presentation/dto/request/ListCreateRequest.java
@@ -1,6 +1,8 @@
 package com.listywave.list.presentation.dto.request;
 
 import com.listywave.list.application.domain.category.CategoryType;
+import com.listywave.list.application.domain.list.BackgroundColor;
+import com.listywave.list.application.domain.list.BackgroundPalette;
 import java.util.List;
 
 public record ListCreateRequest(
@@ -10,7 +12,8 @@ public record ListCreateRequest(
         String title,
         String description,
         Boolean isPublic,
-        String backgroundColor,
+        BackgroundPalette backgroundPalette,
+        BackgroundColor backgroundColor,
         List<ItemCreateRequest> items
 ) {
 }

--- a/src/main/java/com/listywave/list/presentation/dto/request/ListUpdateRequest.java
+++ b/src/main/java/com/listywave/list/presentation/dto/request/ListUpdateRequest.java
@@ -1,6 +1,8 @@
 package com.listywave.list.presentation.dto.request;
 
 import com.listywave.list.application.domain.category.CategoryType;
+import com.listywave.list.application.domain.list.BackgroundColor;
+import com.listywave.list.application.domain.list.BackgroundPalette;
 import java.util.List;
 
 public record ListUpdateRequest(
@@ -10,7 +12,8 @@ public record ListUpdateRequest(
         String title,
         String description,
         boolean isPublic,
-        String backgroundColor,
+        BackgroundPalette backgroundPalette,
+        BackgroundColor backgroundColor,
         List<ItemCreateRequest> items
 ) {
 }

--- a/src/main/java/com/listywave/user/application/dto/FindFeedListResponse.java
+++ b/src/main/java/com/listywave/user/application/dto/FindFeedListResponse.java
@@ -40,7 +40,7 @@ public record FindFeedListResponse(
                     .id(list.getId())
                     .title(list.getTitle().getValue())
                     .isPublic(list.isPublic())
-                    .backgroundColor(list.getBackgroundColor())
+                    .backgroundColor(list.getBackgroundColor().name())
                     .listItems(ListItemsResponse.toList(list.getSortedItems().getValues()))
                     .build();
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,9 @@
 spring:
   datasource:
-    url: jdbc:h2:tcp://localhost/~/listywave;MODE=MySQL
-    username: sa
-    driver-class-name: org.h2.Driver
+    url: jdbc:mysql://localhost:3306/listywave
+    username: root
+    password: root
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: create

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -61,6 +61,7 @@ import com.listywave.list.application.dto.response.ListRecentResponse;
 import com.listywave.list.application.dto.response.ListSearchResponse;
 import com.listywave.list.application.dto.response.ListTrandingResponse;
 import com.listywave.list.presentation.dto.request.ListCreateRequest;
+import com.listywave.list.presentation.dto.request.ListUpdateRequest;
 import com.listywave.user.application.domain.User;
 import com.listywave.user.application.dto.FindFeedListResponse;
 import com.listywave.user.application.dto.FindFeedListResponse.FeedListInfo;
@@ -221,7 +222,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
             ListEntity 동호_리스트 = 리스트를_저장한다(가장_좋아하는_견종_TOP3(동호, List.of()));
             String 동호_액세스_토큰 = 액세스_토큰을_발급한다(동호);
 
-            ListCreateRequest 리스트_수정_요청_데이터 = 아이템_순위와_라벨이_바뀐_좋아하는_견종_TOP3_요청_데이터(List.of());
+            ListUpdateRequest 리스트_수정_요청_데이터 = 아이템_순위와_라벨이_바뀐_좋아하는_견종_TOP3_요청_데이터(List.of());
             리스트_수정_API_호출(리스트_수정_요청_데이터, 동호_액세스_토큰, 동호_리스트.getId());
 
             // when
@@ -263,7 +264,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
             ListCreateResponse 동호_리스트_생성_결과 = 리스트_저장_API_호출(좋아하는_견종_TOP3_생성_요청_데이터(List.of(정수.getId())), 동호_액세스_토큰).as(ListCreateResponse.class);
 
             // when
-            ListCreateRequest 리스트_수정_요청_데이터 = 아이템_순위와_라벨이_바뀐_좋아하는_견종_TOP3_요청_데이터(List.of(유진.getId()));
+            ListUpdateRequest 리스트_수정_요청_데이터 = 아이템_순위와_라벨이_바뀐_좋아하는_견종_TOP3_요청_데이터(List.of(유진.getId()));
             리스트_수정_API_호출(리스트_수정_요청_데이터, 동호_액세스_토큰, 동호_리스트_생성_결과.listId());
 
             // then
@@ -277,10 +278,10 @@ public class ListAcceptanceTest extends AcceptanceTest {
         void 아이템_순위에_변동이_있으면_히스토리로_기록된다() {
             // given
             User 동호 = 회원을_저장한다(동호());
-            ListEntity 동호_리스트 = 리스트를_저장한다(가장_좋아하는_견종_TOP3(동호, List.of()));
             String 동호_액세스_토큰 = 액세스_토큰을_발급한다(동호);
+            ListEntity 동호_리스트 = 리스트를_저장한다(가장_좋아하는_견종_TOP3(동호, List.of()));
 
-            ListCreateRequest 리스트_수정_요청_데이터 = 아이템_순위와_라벨이_바뀐_좋아하는_견종_TOP3_요청_데이터(List.of());
+            ListUpdateRequest 리스트_수정_요청_데이터 = 아이템_순위와_라벨이_바뀐_좋아하는_견종_TOP3_요청_데이터(List.of());
             리스트_수정_API_호출(리스트_수정_요청_데이터, 동호_액세스_토큰, 동호_리스트.getId());
 
             // when
@@ -309,7 +310,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
             ListCreateResponse 좋아하는_견종_TOP3_생성_결과 = 리스트_저장_API_호출(좋아하는_견종_TOP3_생성_요청_데이터(List.of(정수.getId())), 동호_액세스_토큰).as(ListCreateResponse.class);
 
             // when
-            ListCreateRequest 수정_요청_데이터 = 아이템_순위와_라벨이_바뀐_좋아하는_견종_TOP3_요청_데이터(List.of(정수.getId()));
+            ListUpdateRequest 수정_요청_데이터 = 아이템_순위와_라벨이_바뀐_좋아하는_견종_TOP3_요청_데이터(List.of(정수.getId()));
             ExtractableResponse<Response> 동호가_보낸_리스트_수정_API = 리스트_수정_API_호출(수정_요청_데이터, 동호_액세스_토큰, 좋아하는_견종_TOP3_생성_결과.listId());
             ExtractableResponse<Response> 정수가_보낸_리스트_수정_API = 리스트_수정_API_호출(수정_요청_데이터, 정수_액세스_토큰, 좋아하는_견종_TOP3_생성_결과.listId());
             ExtractableResponse<Response> 유진이_보낸_리스트_수정_API = 리스트_수정_API_호출(수정_요청_데이터, 유진_액세스_토큰, 좋아하는_견종_TOP3_생성_결과.listId());

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTestHelper.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTestHelper.java
@@ -8,11 +8,14 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import com.listywave.history.application.dto.HistorySearchResponse;
 import com.listywave.history.application.dto.HistorySearchResponse.HistoryItemInfo;
 import com.listywave.list.application.domain.category.CategoryType;
+import com.listywave.list.application.domain.list.BackgroundColor;
+import com.listywave.list.application.domain.list.BackgroundPalette;
 import com.listywave.list.application.domain.list.ListEntity;
 import com.listywave.list.application.dto.response.ListDetailResponse;
 import com.listywave.list.application.dto.response.ListDetailResponse.ItemResponse;
 import com.listywave.list.presentation.dto.request.ItemCreateRequest;
 import com.listywave.list.presentation.dto.request.ListCreateRequest;
+import com.listywave.list.presentation.dto.request.ListUpdateRequest;
 import com.listywave.user.application.domain.User;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.ExtractableResponse;
@@ -46,7 +49,7 @@ public abstract class ListAcceptanceTestHelper {
                 .as(ListDetailResponse.class);
     }
 
-    public static ExtractableResponse<Response> 리스트_수정_API_호출(ListCreateRequest request, String accessToken, Long listId) {
+    public static ExtractableResponse<Response> 리스트_수정_API_호출(ListUpdateRequest request, String accessToken, Long listId) {
         return given()
                 .header(AUTHORIZATION, "Bearer " + accessToken)
                 .body(request)
@@ -63,7 +66,8 @@ public abstract class ListAcceptanceTestHelper {
                 "좋아하는 견종 TOP 3",
                 "지극히 주관적인 내가 가장 좋아하는 견종 3위까지",
                 true,
-                "green",
+                BackgroundPalette.PASTEL,
+                BackgroundColor.PASTEL_GREEN,
                 List.of(
                         new ItemCreateRequest(1, "말티즈", "", "", ""),
                         new ItemCreateRequest(2, "불독", "", "", ""),
@@ -72,15 +76,16 @@ public abstract class ListAcceptanceTestHelper {
         );
     }
 
-    public static ListCreateRequest 아이템_순위와_라벨이_바뀐_좋아하는_견종_TOP3_요청_데이터(List<Long> collaboratorIds) {
-        return new ListCreateRequest(
+    public static ListUpdateRequest 아이템_순위와_라벨이_바뀐_좋아하는_견종_TOP3_요청_데이터(List<Long> collaboratorIds) {
+        return new ListUpdateRequest(
                 ANIMAL_PLANT,
                 List.of("냐옹", "멍멍"),
                 collaboratorIds,
                 "좋아하는 견종 TOP 3",
                 "지극히 주관적인 내가 가장 좋아하는 견종 3위까지",
                 true,
-                "green",
+                BackgroundPalette.PASTEL,
+                BackgroundColor.PASTEL_GREEN,
                 List.of(
                         new ItemCreateRequest(1, "불독", "", "", ""),
                         new ItemCreateRequest(2, "골든 리트리버", "", "", ""),
@@ -97,7 +102,8 @@ public abstract class ListAcceptanceTestHelper {
                 "좋아하는 라면 TOP 3",
                 "신라면, 육개장 사발면, 김치 사발면 진리",
                 true,
-                "RED",
+                BackgroundPalette.PASTEL,
+                BackgroundColor.PASTEL_GREEN,
                 List.of(
                         new ItemCreateRequest(1, "신라면", "", "", ""),
                         new ItemCreateRequest(2, "육개장 사발면", "", "", ""),

--- a/src/test/java/com/listywave/collaborator/application/domain/CollaboratorsTest.java
+++ b/src/test/java/com/listywave/collaborator/application/domain/CollaboratorsTest.java
@@ -15,6 +15,8 @@ import com.listywave.list.application.domain.item.ItemLink;
 import com.listywave.list.application.domain.item.ItemTitle;
 import com.listywave.list.application.domain.item.Items;
 import com.listywave.list.application.domain.label.Labels;
+import com.listywave.list.application.domain.list.BackgroundColor;
+import com.listywave.list.application.domain.list.BackgroundPalette;
 import com.listywave.list.application.domain.list.ListDescription;
 import com.listywave.list.application.domain.list.ListEntity;
 import com.listywave.list.application.domain.list.ListTitle;
@@ -41,7 +43,8 @@ class CollaboratorsTest {
                 new ListTitle("리스트 제목"),
                 new ListDescription("리스트 설명"),
                 true,
-                "#ab34df",
+                BackgroundPalette.PASTEL,
+                BackgroundColor.PASTEL_GREEN,
                 false,
                 new Labels(List.of()),
                 new Items(List.of(
@@ -83,11 +86,24 @@ class CollaboratorsTest {
             User userC = User.init(3L, "cccc@naver.com", "cccc");
             User userD = User.init(4L, "dddd@naver.com", "dddd");
 
-            ListEntity list = new ListEntity(userA, ETC, new ListTitle("title"), new ListDescription("description"), true, "#123345", true, new Labels(List.of()), new Items(List.of(
-                    Item.init(1, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
-                    Item.init(2, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
-                    Item.init(3, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1)))
-            )));
+            ListEntity list = new ListEntity(
+                    userA,
+                    ETC,
+                    new ListTitle("title"),
+                    new ListDescription("description"),
+                    true,
+                    BackgroundPalette.PASTEL,
+                    BackgroundColor.PASTEL_GREEN,
+                    true,
+                    new Labels(List.of()),
+                    new Items(
+                            List.of(
+                                    Item.init(1, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
+                                    Item.init(2, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
+                                    Item.init(3, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1)))
+                            )
+                    )
+            );
 
             Collaborators beforeCollaborators = new Collaborators(List.of(
                     Collaborator.init(userA, list),
@@ -112,11 +128,24 @@ class CollaboratorsTest {
             User userA = User.init(1L, "aaaa@naver.com", "aaaa");
             User userC = User.init(3L, "cccc@naver.com", "cccc");
 
-            ListEntity list = new ListEntity(userA, ETC, new ListTitle("title"), new ListDescription("description"), true, "#123345", true, new Labels(List.of()), new Items(List.of(
-                    Item.init(1, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
-                    Item.init(2, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
-                    Item.init(3, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1)))
-            )));
+            ListEntity list = new ListEntity(
+                    userA,
+                    ETC,
+                    new ListTitle("title"),
+                    new ListDescription("description"),
+                    true,
+                    BackgroundPalette.GRAY,
+                    BackgroundColor.GRAY_LIGHT,
+                    true,
+                    new Labels(List.of()),
+                    new Items(
+                            List.of(
+                                    Item.init(1, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
+                                    Item.init(2, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
+                                    Item.init(3, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1)))
+                            )
+                    )
+            );
 
             Collaborators beforeCollaborators = new Collaborators(List.of(
             ));
@@ -136,11 +165,24 @@ class CollaboratorsTest {
         void 콜라보레이터가_변경되기_전_후로_동일할_때_필터링_테스트() {
             // given
             User userA = User.init(1L, "aaaa@naver.com", "aaaa");
-            ListEntity list = new ListEntity(userA, ETC, new ListTitle("title"), new ListDescription("description"), true, "#123345", true, new Labels(List.of()), new Items(List.of(
-                    Item.init(1, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
-                    Item.init(2, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
-                    Item.init(3, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1)))
-            )));
+            ListEntity list = new ListEntity(
+                    userA,
+                    ETC,
+                    new ListTitle("title"),
+                    new ListDescription("description"),
+                    true,
+                    BackgroundPalette.GRAY,
+                    BackgroundColor.GRAY_LIGHT,
+                    true,
+                    new Labels(List.of()),
+                    new Items(
+                            List.of(
+                                    Item.init(1, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
+                                    Item.init(2, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1))),
+                                    Item.init(3, new ItemTitle(String.valueOf(1)), new ItemComment(String.valueOf(1)), new ItemLink(String.valueOf(1)), new ItemImageUrl(String.valueOf(1)))
+                            )
+                    )
+            );
 
             Collaborators beforeCollaborators = new Collaborators(List.of(Collaborator.init(userA, list)));
             Collaborators afterCollaborators = new Collaborators(List.of(Collaborator.init(userA, list)));
@@ -210,14 +252,17 @@ class CollaboratorsTest {
                             new ListTitle(String.valueOf(i)),
                             new ListDescription(String.valueOf(i)),
                             true,
-                            String.valueOf(i),
+                            BackgroundPalette.LISTY,
+                            BackgroundColor.LISTY_BLUE,
                             false,
                             new Labels(List.of()),
-                            new Items(List.of(
-                                    Item.init((int) i, new ItemTitle(String.valueOf(i)), new ItemComment(String.valueOf(i)), new ItemLink(String.valueOf(i)), new ItemImageUrl(String.valueOf(i))),
-                                    Item.init((int) i + 1, new ItemTitle(String.valueOf(i)), new ItemComment(String.valueOf(i)), new ItemLink(String.valueOf(i)), new ItemImageUrl(String.valueOf(i))),
-                                    Item.init((int) i + 2, new ItemTitle(String.valueOf(i)), new ItemComment(String.valueOf(i)), new ItemLink(String.valueOf(i)), new ItemImageUrl(String.valueOf(i)))
-                            ))
+                            new Items(
+                                    List.of(
+                                            Item.init((int) i, new ItemTitle(String.valueOf(i)), new ItemComment(String.valueOf(i)), new ItemLink(String.valueOf(i)), new ItemImageUrl(String.valueOf(i))),
+                                            Item.init((int) i + 1, new ItemTitle(String.valueOf(i)), new ItemComment(String.valueOf(i)), new ItemLink(String.valueOf(i)), new ItemImageUrl(String.valueOf(i))),
+                                            Item.init((int) i + 2, new ItemTitle(String.valueOf(i)), new ItemComment(String.valueOf(i)), new ItemLink(String.valueOf(i)), new ItemImageUrl(String.valueOf(i)))
+                                    )
+                            )
                     );
                     return Collaborator.init(user, list);
                 }).toList();

--- a/src/test/java/com/listywave/list/application/domain/list/ListEntityTest.java
+++ b/src/test/java/com/listywave/list/application/domain/list/ListEntityTest.java
@@ -42,7 +42,8 @@ class ListEntityTest {
     private final ListTitle title = new ListTitle("칼국수 맛집 TOP 10");
     private final ListDescription description = new ListDescription("박박우기는 칼국수 맛집");
     private final boolean isPublic = true;
-    private final String backgroundColor = "RED";
+    private final BackgroundPalette backGroundPalette = BackgroundPalette.GRAY;
+    private final BackgroundColor backgroundColor = BackgroundColor.GRAY_LIGHT;
     private final boolean hasCollaboration = false;
     private final Labels labels = new Labels(List.of(
             Label.init(new LabelName("대전")),
@@ -56,7 +57,7 @@ class ListEntityTest {
             Item.init(4, new ItemTitle("전주집"), new ItemComment("전주집 맛집임"), new ItemLink(""), new ItemImageUrl("")),
             Item.init(5, new ItemTitle("경주집"), new ItemComment("경주 여행가고 싶다"), new ItemLink(""), new ItemImageUrl(""))
     ));
-    private final ListEntity list = new ListEntity(user, categoryType, title, description, isPublic, backgroundColor, hasCollaboration, labels, items);
+    private final ListEntity list = new ListEntity(user, categoryType, title, description, isPublic, backGroundPalette, backgroundColor, hasCollaboration, labels, items);
 
     @Test
     void 아이템을_순위대로_정렬해서_반환한다() {
@@ -194,7 +195,7 @@ class ListEntityTest {
                 Item.init(2, new ItemTitle("동호집"), new ItemComment("동호집 칼국수가 젤 맛있음ㅋㅋ"), new ItemLink(""), new ItemImageUrl("")),
                 Item.init(3, new ItemTitle("정수집"), new ItemComment("정수네가 꼴찌"), new ItemLink(""), new ItemImageUrl("https://naver.com"))
         ));
-        ListEntity list = new ListEntity(user, categoryType, title, description, isPublic, backgroundColor, hasCollaboration, labels, items);
+        ListEntity list = new ListEntity(user, categoryType, title, description, isPublic, backGroundPalette, backgroundColor, hasCollaboration, labels, items);
 
         String result = list.getRepresentImageUrl();
 

--- a/src/test/java/com/listywave/list/fixture/ListFixture.java
+++ b/src/test/java/com/listywave/list/fixture/ListFixture.java
@@ -14,10 +14,13 @@ import com.listywave.list.application.domain.item.Items;
 import com.listywave.list.application.domain.label.Label;
 import com.listywave.list.application.domain.label.LabelName;
 import com.listywave.list.application.domain.label.Labels;
+import com.listywave.list.application.domain.list.BackgroundColor;
+import com.listywave.list.application.domain.list.BackgroundPalette;
 import com.listywave.list.application.domain.list.ListDescription;
 import com.listywave.list.application.domain.list.ListEntity;
 import com.listywave.list.application.domain.list.ListTitle;
 import com.listywave.list.presentation.dto.request.ListCreateRequest;
+import com.listywave.list.presentation.dto.request.ListUpdateRequest;
 import com.listywave.user.application.domain.User;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -43,14 +46,21 @@ public abstract class ListFixture {
                 )).toList());
 
         return new ListEntity(
-                owner, request.category(), new ListTitle(request.title()),
-                new ListDescription(request.description()), request.isPublic(),
-                request.backgroundColor(), hasCollaborators, labels, items
+                owner,
+                request.category(),
+                new ListTitle(request.title()),
+                new ListDescription(request.description()),
+                request.isPublic(),
+                request.backgroundPalette(),
+                request.backgroundColor(),
+                hasCollaborators,
+                labels,
+                items
         );
     }
 
     public static ListEntity 가장_좋아하는_견종_TOP3_순위_변경(User owner, List<Long> collaboratorIds) {
-        ListCreateRequest request = 아이템_순위와_라벨이_바뀐_좋아하는_견종_TOP3_요청_데이터(collaboratorIds);
+        ListUpdateRequest request = 아이템_순위와_라벨이_바뀐_좋아하는_견종_TOP3_요청_데이터(collaboratorIds);
         boolean hasCollaborators = !request.collaboratorIds().isEmpty();
 
         Labels labels = new Labels(request.labels().stream()
@@ -68,9 +78,16 @@ public abstract class ListFixture {
                 )).toList());
 
         return new ListEntity(
-                owner, request.category(), new ListTitle(request.title()),
-                new ListDescription(request.description()), request.isPublic(),
-                request.backgroundColor(), hasCollaborators, labels, items
+                owner,
+                request.category(),
+                new ListTitle(request.title()),
+                new ListDescription(request.description()),
+                request.isPublic(),
+                request.backgroundPalette(),
+                request.backgroundColor(),
+                hasCollaborators,
+                labels,
+                items
         );
     }
 
@@ -93,9 +110,16 @@ public abstract class ListFixture {
                 )).toList());
 
         return new ListEntity(
-                owner, request.category(), new ListTitle(request.title()),
-                new ListDescription(request.description()), request.isPublic(),
-                request.backgroundColor(), hasCollaborators, labels, items
+                owner,
+                request.category(),
+                new ListTitle(request.title()),
+                new ListDescription(request.description()),
+                request.isPublic(),
+                request.backgroundPalette(),
+                request.backgroundColor(),
+                hasCollaborators,
+                labels,
+                items
         );
     }
 
@@ -107,7 +131,8 @@ public abstract class ListFixture {
                         new ListTitle(i + "번째 리스트"),
                         new ListDescription(i + "번째 리스트"),
                         true,
-                        "#123456",
+                        BackgroundPalette.GRAY,
+                        BackgroundColor.PASTEL_GREEN,
                         false,
                         new Labels(List.of()),
                         new Items(List.of(


### PR DESCRIPTION
# Description
## 작업한 내용
1. ListEntity에 String 타입이었던 _backgroundColor_ 필드를 **BackgroundColor Enum** 타입으로 변경
2. ListEntity에 B**ackgroundPalette Enum** 타입 추가
3. 리스트 생성, 수정, 조회 API에 생긴 변경 사항을 Request, Response DTO에 반영 (ListCreateRequest, ListUpdateRequest 등)
4. 도메인 및 DTO 필드 수정으로 인한 테스트 코드 변경 사항 반영
5. Local용 DB에 접속하는 설정 정보를 Docker로 띄운 Mysql에 접속하도록 변경
6. ListAcceptanceTest에서 리스트 수정 관련 테스트인데 ListCreateRequest를 사용하고 있던 걸 ListUpdateRequest를 사용하도록 변경

## 🚨 Merge하기 전 꼭 해야 할 사항 !! 🚨
1. 기존 Hex Code 값을 String 타입으로 가지고 있던 _background_color_ 칼럼을 모두 해당하는 Color 이름으로 변경한다. (ㅜㅜ) 
2. _List_ 테이블에 _background_palette_ 칼럼을 추가한다.

# Relation Issues
- close #256 
