### PR TITLE
fix: 히스토리 찍힘 문제 해결

### DIFF
--- a/src/main/java/com/listywave/collaborator/application/service/CollaboratorService.java
+++ b/src/main/java/com/listywave/collaborator/application/service/CollaboratorService.java
@@ -1,7 +1,6 @@
 package com.listywave.collaborator.application.service;
 
 import static org.springframework.transaction.annotation.Propagation.REQUIRED;
-import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
 import com.listywave.collaborator.application.domain.Collaborator;
 import com.listywave.collaborator.application.domain.Collaborators;
@@ -20,7 +19,7 @@ public class CollaboratorService {
     private final UserRepository userRepository;
     private final CollaboratorRepository collaboratorRepository;
 
-    @Transactional(readOnly = true, propagation = REQUIRES_NEW)
+    @Transactional(readOnly = true, propagation = REQUIRED)
     public Collaborators createCollaborators(List<Long> userIds, ListEntity list) {
         return new Collaborators(userIds.stream()
                 .map(userRepository::getById)
@@ -36,5 +35,24 @@ public class CollaboratorService {
     @Transactional(propagation = REQUIRED)
     public List<Collaborator> saveAll(Collaborators collaborators) {
         return collaboratorRepository.saveAll(collaborators.collaborators());
+    }
+
+    @Transactional(propagation = REQUIRED)
+    public void updateCollaborators(Collaborators beforeCollaborators, Collaborators newCollaborators) {
+        Collaborators removedCollaborators = beforeCollaborators.filterRemovedCollaborators(newCollaborators);
+        collaboratorRepository.deleteAllInBatch(removedCollaborators.collaborators());
+
+        Collaborators addedCollaborators = beforeCollaborators.filterAddedCollaborators(newCollaborators);
+        collaboratorRepository.saveAll(addedCollaborators.collaborators());
+    }
+
+    @Transactional(propagation = REQUIRED)
+    public void deleteAllByList(ListEntity list) {
+        collaboratorRepository.deleteAllByList(list);
+    }
+
+    @Transactional(propagation = REQUIRED)
+    public void deleteAllByListIn(List<ListEntity> lists) {
+        collaboratorRepository.deleteAllByListIn(lists);
     }
 }

--- a/src/main/java/com/listywave/history/application/domain/History.java
+++ b/src/main/java/com/listywave/history/application/domain/History.java
@@ -17,6 +17,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Temporal;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -68,5 +69,11 @@ public class History {
             return;
         }
         isPublic = true;
+    }
+
+    public List<HistoryItem> sortedItems() {
+        return items.stream()
+                .sorted(Comparator.comparing(HistoryItem::getRank))
+                .toList();
     }
 }

--- a/src/main/java/com/listywave/history/application/dto/HistorySearchResponse.java
+++ b/src/main/java/com/listywave/history/application/dto/HistorySearchResponse.java
@@ -23,7 +23,7 @@ public record HistorySearchResponse(
                 history.getId(),
                 history.getCreatedDate(),
                 history.isPublic(),
-                HistoryItemInfo.toList(history.getItems())
+                HistoryItemInfo.toList(history.sortedItems())
         );
     }
 

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -8,7 +8,6 @@ import com.listywave.alarm.repository.AlarmRepository;
 import com.listywave.collaborator.application.domain.Collaborator;
 import com.listywave.collaborator.application.domain.Collaborators;
 import com.listywave.collaborator.application.service.CollaboratorService;
-import com.listywave.collaborator.repository.CollaboratorRepository;
 import com.listywave.collection.repository.CollectionRepository;
 import com.listywave.common.exception.CustomException;
 import com.listywave.history.application.service.HistoryService;
@@ -74,7 +73,6 @@ public class ListService {
     private final ItemRepository itemRepository;
     private final LabelRepository labelRepository;
     private final CollectionRepository collectionRepository;
-    private final CollaboratorRepository collaboratorRepository;
     private final AlarmRepository alarmRepository;
     private final CollaboratorService collaboratorService;
     private final HistoryService historyService;
@@ -140,7 +138,7 @@ public class ListService {
     public ListDetailResponse getListDetail(Long listId, Long loginUserId) {
         ListEntity list = listRepository.getById(listId);
         list.validateOwnerIsNotDelete();
-        List<Collaborator> collaborators = collaboratorRepository.findAllByList(list);
+        List<Collaborator> collaborators = collaboratorService.findAllByList(list).collaborators();
 
         boolean isCollected = false;
         if (loginUserId != null) {
@@ -166,7 +164,7 @@ public class ListService {
         collectionRepository.deleteAllByList(list);
         alarmRepository.deleteAllByListId(list.getId());
         imageService.deleteAllOfListImages(listId);
-        collaboratorRepository.deleteAllByList(list);
+        collaboratorService.deleteAllByList(list);
         List<Comment> comments = commentRepository.findAllByList(list);
         replyRepository.deleteAllByCommentIn(comments);
         commentRepository.deleteAllInBatch(comments);
@@ -236,7 +234,7 @@ public class ListService {
         Collaborators beforeCollaborators = collaboratorService.findAllByList(list);
         list.validateUpdateAuthority(loginUser, beforeCollaborators);
         Collaborators newCollaborators = collaboratorService.createCollaborators(request.collaboratorIds(), list);
-        updateCollaborators(beforeCollaborators, newCollaborators);
+        collaboratorService.updateCollaborators(beforeCollaborators, newCollaborators);
 
         Labels newLabels = createLabels(request.labels());
         Items newItems = createItems(request.items());
@@ -263,14 +261,6 @@ public class ListService {
         }
     }
 
-    private void updateCollaborators(Collaborators beforeCollaborators, Collaborators newCollaborators) {
-        Collaborators removedCollaborators = beforeCollaborators.filterRemovedCollaborators(newCollaborators);
-        collaboratorRepository.deleteAllInBatch(removedCollaborators.collaborators());
-
-        Collaborators addedCollaborators = beforeCollaborators.filterAddedCollaborators(newCollaborators);
-        collaboratorRepository.saveAll(addedCollaborators.collaborators());
-    }
-
     public void deleteLists(Long loginUserId, List<Long> listIds) {
         List<ListEntity> lists = listRepository.findAllById(listIds);
         if (lists.isEmpty()) {
@@ -282,7 +272,7 @@ public class ListService {
         deleteListImages(lists);
         alarmRepository.deleteAllByListIdIn(listIds);
         collectionRepository.deleteAllByListIn(lists);
-        collaboratorRepository.deleteAllByListIn(lists);
+        collaboratorService.deleteAllByListIn(lists);
         List<Comment> comments = commentRepository.findAllByListIn(lists);
         replyRepository.deleteAllByCommentIn(comments);
         commentRepository.deleteAllInBatch(comments);

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -279,21 +279,23 @@ public class ListAcceptanceTest extends AcceptanceTest {
             // given
             User 동호 = 회원을_저장한다(동호());
             String 동호_액세스_토큰 = 액세스_토큰을_발급한다(동호);
-            ListEntity 동호_리스트 = 리스트를_저장한다(가장_좋아하는_견종_TOP3(동호, List.of()));
+            Long 생성된_리스트의_ID = 리스트_저장_API_호출(좋아하는_견종_TOP3_생성_요청_데이터(List.of()), 동호_액세스_토큰)
+                    .as(ListCreateResponse.class)
+                    .listId();
 
             ListUpdateRequest 리스트_수정_요청_데이터 = 아이템_순위와_라벨이_바뀐_좋아하는_견종_TOP3_요청_데이터(List.of());
-            리스트_수정_API_호출(리스트_수정_요청_데이터, 동호_액세스_토큰, 동호_리스트.getId());
+            리스트_수정_API_호출(리스트_수정_요청_데이터, 동호_액세스_토큰, 생성된_리스트의_ID);
 
             // when
-            List<HistorySearchResponse> 히스토리_조회_결과 = 비회원_히스토리_조회_API_호출(동호_리스트.getId());
-            ListDetailResponse 수정된_리스트_상세_조회_결과 = 비회원_리스트_상세_조회_API_호출(동호_리스트.getId()).as(ListDetailResponse.class);
+            List<HistorySearchResponse> 히스토리_조회_결과 = 비회원_히스토리_조회_API_호출(생성된_리스트의_ID);
+            ListDetailResponse 수정된_리스트_상세_조회_결과 = 비회원_리스트_상세_조회_API_호출(생성된_리스트의_ID).as(ListDetailResponse.class);
 
             // then
             List<ItemResponse> 수정된_리스트의_아이템_정보들 = 수정된_리스트_상세_조회_결과.items();
-            List<HistoryItemInfo> 히스토리의_아이템_정보들 = 히스토리_조회_결과.get(0).items();
+            List<HistoryItemInfo> 히스토리의_아이템_정보들 = 히스토리_조회_결과.get(히스토리_조회_결과.size() - 1).items();
             assertAll(
-                    () -> assertThat(히스토리_조회_결과.size()).isOne(),
-                    () -> assertThat(히스토리_조회_결과.get(0).createdDate()).isEqualTo(수정된_리스트_상세_조회_결과.lastUpdatedDate()),
+                    () -> assertThat(히스토리_조회_결과.size()).isEqualTo(2),
+                    () -> assertThat(히스토리_조회_결과.get(히스토리_조회_결과.size() - 1).createdDate()).isEqualTo(수정된_리스트_상세_조회_결과.lastUpdatedDate()),
                     () -> 리스트의_아이템_순위와_히스토리의_아이템_순위를_검증한다(수정된_리스트의_아이템_정보들, 히스토리의_아이템_정보들)
             );
         }

--- a/src/test/java/com/listywave/history/application/domain/HistoryTest.java
+++ b/src/test/java/com/listywave/history/application/domain/HistoryTest.java
@@ -22,9 +22,9 @@ class HistoryTest {
     private final User user = 동호();
     private final ListEntity list = 가장_좋아하는_견종_TOP3(user, List.of());
     private final List<HistoryItem> historyItems = List.of(
-            new HistoryItem(1, new HistoryItemTitle("1등")),
+            new HistoryItem(2, new HistoryItemTitle("1등")),
             new HistoryItem(1, new HistoryItemTitle("2등")),
-            new HistoryItem(1, new HistoryItemTitle("3등"))
+            new HistoryItem(3, new HistoryItemTitle("3등"))
     );
 
     @Test
@@ -45,5 +45,20 @@ class HistoryTest {
 
         history.updatePublic();
         assertThat(history.isPublic()).isTrue();
+    }
+
+    @Test
+    void 히스토리_아이템의_순위대로_정렬하여_반환한다() {
+        // given
+        History history = new History(list, historyItems, now(), true);
+
+        // when
+        List<HistoryItem> result = history.sortedItems();
+
+        // then
+        assertThat(result.stream()
+                .map(HistoryItem::getRank)
+                .toList()
+        ).isEqualTo(List.of(1, 2, 3));
     }
 }


### PR DESCRIPTION
# 작업한 내용
1. 히스토리가 찍히는 문제를 해결했습니다.
2. 히스토리 조회 응답에 히스토리 아이템을 순위대로 정렬하여 응답하도록 개선했습니다.

# Relation Issues
- close #258 