### PR TITLE
 feat: 아이템 순위에 변동이 있을 때만 리스트의 lastUpdatedDate가 갱신되도록 구현

### DIFF
--- a/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
+++ b/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
@@ -200,6 +200,7 @@ public class ListEntity {
             BackgroundColor backgroundColor,
             boolean hasCollaboration,
             LocalDateTime updatedDate,
+            boolean doesChangedAnyItemRank,
             Labels newLabels,
             Items newItems
     ) {
@@ -210,8 +211,10 @@ public class ListEntity {
         this.backgroundPalette = backgroundPalette;
         this.backgroundColor = backgroundColor;
         this.hasCollaboration = hasCollaboration;
-        this.updatedDate = updatedDate;
 
+        if (doesChangedAnyItemRank) {
+            this.updatedDate = updatedDate;
+        }
         if (this.labels.isChange(newLabels)) {
             this.labels.updateAll(newLabels, this);
         }

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -252,6 +252,7 @@ public class ListService {
                 request.backgroundColor(),
                 hasCollaborator,
                 updatedDate,
+                doesChangedAnyItemRank,
                 newLabels,
                 newItems
         );


### PR DESCRIPTION
# 작업 내용
1. 아이템 순위에 변동이 있을 때, 즉 `doesChangedAnyItemRank`가 `true`일 때만 `lastUpdatedDate`를 갱신하도록 구현했습니다.
2. 테스트 코드도 작성했습니다.

# Relation Issues
- close #261 
