### PR TITLE
infra: Prod용 배포 자동화 구축

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -1,0 +1,58 @@
+name: Deploy to PROD
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "prod" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 저장소 Checkout
+        uses: actions/checkout@v4
+
+      - name: 설정 파일 추가
+        run: |
+          cd /src/main/resources/
+          
+          cat <<EOF > application-prod.yml
+          ${{ APPLICATION_PROD_YML }}
+          EOF
+          
+          cat <<EOF > application-oauth.yml
+          ${{ APPLICATION_OAUTH_YML }}
+          EOF
+          
+          cat <<EOF > application-storage.yml
+          ${{ APPLICATION_STORAGE_YML }}
+          EOF
+
+      - name: 애플리케이션 빌드
+        run: ./gradlew bootJar
+
+      - name: 도커 이미지 빌드
+        run: docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.IMAGE_NAME }}:${{ secrets.PROD_TAG }} ./
+
+      - name: 도커 허브에 로그인
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: 도커 허브에 Push
+        run: docker push ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.IMAGE_NAME }}:${{ secrets.PROD_TAG }}
+
+      - name: 인스턴스 접속 및 배포 스크립트 실행
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.PROD_EC2_HOST }}
+          username: ${{ secrets.PROD_EC2_USERNAME }}
+          password: ${{ secrets.PROD_EC2_PASSWORD }}
+          port: ${{ secrets.PROD_EC2_PORT }}
+          script: |
+            docker stop ${{ secrets.PROD_CONTAINER_NAME }}
+            docker rm -f ${{ secrets.PROD_CONTAINER_NAME }}
+            docker rmi ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.IMAGE_NAME }}:${{ secrets.PROD_TAG }}
+            docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.IMAGE_NAME }}:${{ secrets.PROD_TAG }}
+            docker run -d -p 8080:8080 --name ${{ secrets.PROD_CONTAINER_NAME }} ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.IMAGE_NAME }}:${{ secrets.PROD_TAG }}

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -17,15 +17,15 @@ jobs:
           cd /src/main/resources/
           
           cat <<EOF > application-prod.yml
-          ${{ APPLICATION_PROD_YML }}
+          ${{ secrets.APPLICATION_PROD_YML }}
           EOF
           
           cat <<EOF > application-oauth.yml
-          ${{ APPLICATION_OAUTH_YML }}
+          ${{ secrets.APPLICATION_OAUTH_YML }}
           EOF
           
           cat <<EOF > application-storage.yml
-          ${{ APPLICATION_STORAGE_YML }}
+          ${{ secrets.APPLICATION_STORAGE_YML }}
           EOF
 
       - name: 애플리케이션 빌드

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM amazoncorretto:17-alpine-jdk
+
+COPY ./build/libs/listywave.jar listywave.jar
+
+ENV TZ=Asia/Seoul
+
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod,oauth,storage", "-jar", "listywave.jar"]


### PR DESCRIPTION
# Description
Github Actions와 Docker를 이용해 배포 자동화를 구축했습니다.
기대하는 동작 순서는 다음과 같습니다.
  1. prod 브랜치에 push -> prod-cd.yml 워크 플로우가 동작
  2. Actions Host(워크플로우를 실행하는 호스트)에서 Github Repository Secrets에 작성해놓은 설정 파일 내용을 /src/main/resources/ 안에 file로 생성
  3. 준비된 프로젝트를 `./gradlew bootJar` 명령어로 빌드
  4. Dockerfile을 이용해 빌드 결과물을 도커 이미지로 생성
  5. 도커 허브에 로그인 -> 미리 만들어놓은 저장소에 Push
  6. Actions Host에서 인스턴스에 원격으로 접속 -> 컨테이너 띄우도록 명령어 수행

# Relation Issues
- close #251 
