### PR TITLE
feat: Category 관련 응답 필드 추가 및 네이밍 변경

### DIFF
--- a/src/main/java/com/listywave/list/application/dto/response/CategoryTypeResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/CategoryTypeResponse.java
@@ -3,9 +3,9 @@ package com.listywave.list.application.dto.response;
 import com.listywave.list.application.domain.category.CategoryType;
 
 public record CategoryTypeResponse(
-        String codeValue,
-        String nameValue,
-        String korNameValue,
+        String code,
+        String name,
+        String viewName,
         String categoryImageUrl
 ) {
 

--- a/src/main/java/com/listywave/list/application/dto/response/CategoryTypeResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/CategoryTypeResponse.java
@@ -4,8 +4,8 @@ import com.listywave.list.application.domain.category.CategoryType;
 
 public record CategoryTypeResponse(
         String code,
-        String name,
-        String viewName,
+        String engName,
+        String korName,
         String categoryImageUrl
 ) {
 

--- a/src/main/java/com/listywave/list/application/dto/response/ListDetailResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/ListDetailResponse.java
@@ -11,7 +11,8 @@ import lombok.Builder;
 
 @Builder
 public record ListDetailResponse(
-        String category,
+        String categoryName,
+        String categoryViewName,
         List<LabelResponse> labels,
         String title,
         String description,
@@ -37,7 +38,8 @@ public record ListDetailResponse(
             List<Collaborator> collaborators
     ) {
         return ListDetailResponse.builder()
-                .category(list.getCategory().getViewName())
+                .categoryName(list.getCategory().name().toLowerCase())
+                .categoryViewName(list.getCategory().getViewName())
                 .labels(LabelResponse.toList(list.getLabels().getValues()))
                 .title(list.getTitle().getValue())
                 .description(list.getDescription().getValue())

--- a/src/main/java/com/listywave/list/application/dto/response/ListDetailResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/ListDetailResponse.java
@@ -11,8 +11,8 @@ import lombok.Builder;
 
 @Builder
 public record ListDetailResponse(
-        String categoryName,
-        String categoryViewName,
+        String categoryEngName,
+        String categoryKorName,
         List<LabelResponse> labels,
         String title,
         String description,
@@ -38,8 +38,8 @@ public record ListDetailResponse(
             List<Collaborator> collaborators
     ) {
         return ListDetailResponse.builder()
-                .categoryName(list.getCategory().name().toLowerCase())
-                .categoryViewName(list.getCategory().getViewName())
+                .categoryEngName(list.getCategory().name().toLowerCase())
+                .categoryKorName(list.getCategory().getViewName())
                 .labels(LabelResponse.toList(list.getLabels().getValues()))
                 .title(list.getTitle().getValue())
                 .description(list.getDescription().getValue())

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -165,7 +165,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
             assertAll(
                     () -> assertThat(결과.ownerId()).isEqualTo(동호.getId()),
                     () -> assertThat(결과.title()).isEqualTo(동호_리스트.getTitle().getValue()),
-                    () -> assertThat(결과.category()).isEqualTo(동호_리스트.getCategory().getViewName()),
+                    () -> assertThat(결과.categoryViewName()).isEqualTo(동호_리스트.getCategory().getViewName()),
                     () -> assertThat(결과.collectCount()).isZero(),
                     () -> assertThat(결과.collaborators()).isEmpty()
             );

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -165,7 +165,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
             assertAll(
                     () -> assertThat(결과.ownerId()).isEqualTo(동호.getId()),
                     () -> assertThat(결과.title()).isEqualTo(동호_리스트.getTitle().getValue()),
-                    () -> assertThat(결과.categoryViewName()).isEqualTo(동호_리스트.getCategory().getViewName()),
+                    () -> assertThat(결과.categoryKorName()).isEqualTo(동호_리스트.getCategory().getViewName()),
                     () -> assertThat(결과.collectCount()).isZero(),
                     () -> assertThat(결과.collaborators()).isEmpty()
             );


### PR DESCRIPTION
# Description
- ListDetailResponse에 `categoryName`과 `categoryViewName`을 함께 포함합니다.
- `CategoryTypeResponse`의 변수명을 변경했습니다.

# Relation Issues
- close #271 
