### PR TITLE
feat: 로컬용 로그인 API 구현

### DIFF
--- a/src/main/java/com/listywave/auth/presentation/LocalAuthController.java
+++ b/src/main/java/com/listywave/auth/presentation/LocalAuthController.java
@@ -1,0 +1,85 @@
+package com.listywave.auth.presentation;
+
+import static com.listywave.common.exception.ErrorCode.INVALID_ACCESS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+
+import com.listywave.auth.application.domain.JwtManager;
+import com.listywave.auth.presentation.dto.LoginResponse;
+import com.listywave.common.exception.CustomException;
+import com.listywave.common.util.TimeUtils;
+import com.listywave.user.application.domain.User;
+import com.listywave.user.repository.user.UserRepository;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Profile("!prod")
+@RequiredArgsConstructor
+public class LocalAuthController {
+
+    private final UserRepository userRepository;
+    private final JwtManager jwtManager;
+
+    @Value("${local-login.id}")
+    private String id;
+    @Value("${local-login.password}")
+    private String password;
+
+    @GetMapping("/login/local")
+    ResponseEntity<LoginResponse> localLogin(
+            @RequestParam(name = "id") String id,
+            @RequestParam(name = "password") String password
+    ) {
+        if (this.id.equals(id) && this.password.equals(password)) {
+            User user = userRepository.getById(1L);
+
+            String accessToken = jwtManager.createAccessToken(user.getId());
+            String refreshToken = jwtManager.createRefreshToken(user.getId());
+
+            ResponseCookie accessTokenCookie = createCookie(
+                    "accessToken",
+                    accessToken,
+                    Duration.ofSeconds(TimeUtils.convertTimeUnit(
+                            jwtManager.getAccessTokenValidTimeDuration(),
+                            jwtManager.getAccessTokenValidTimeUnit(),
+                            SECONDS
+                    ))
+            );
+            ResponseCookie refreshTokenCookie = createCookie(
+                    "refreshToken",
+                    refreshToken,
+                    Duration.ofSeconds(TimeUtils.convertTimeUnit(
+                            jwtManager.getRefreshTokenValidTimeDuration(),
+                            jwtManager.getRefreshTokenValidTimeUnit(),
+                            SECONDS
+                    ))
+            );
+
+            return ResponseEntity.ok()
+                    .header(SET_COOKIE, accessTokenCookie.toString())
+                    .header(SET_COOKIE, refreshTokenCookie.toString())
+                    .body(LoginResponse.of(user, accessToken, refreshToken));
+        }
+        throw new CustomException(INVALID_ACCESS);
+    }
+
+    private ResponseCookie createCookie(String name, String value, Duration maxAge) {
+        return ResponseCookie.from(name)
+                .value(value)
+                .maxAge(maxAge)
+                .domain("localhost")
+                .path("/")
+                .httpOnly(false)
+                .secure(false)
+                .sameSite("None")
+                .build();
+    }
+}

--- a/src/main/java/com/listywave/auth/presentation/dto/LoginResponse.java
+++ b/src/main/java/com/listywave/auth/presentation/dto/LoginResponse.java
@@ -1,6 +1,7 @@
 package com.listywave.auth.presentation.dto;
 
 import com.listywave.auth.application.dto.LoginResult;
+import com.listywave.user.application.domain.User;
 import lombok.Builder;
 
 @Builder
@@ -29,6 +30,21 @@ public record LoginResponse(
                 .isFirst(result.isFirst())
                 .accessToken(result.accessToken())
                 .refreshToken(result.refreshToken())
+                .build();
+    }
+
+    public static LoginResponse of(User user, String accessToken, String refreshToken) {
+        return LoginResponse.builder()
+                .id(user.getId())
+                .profileImageUrl(user.getProfileImageUrl())
+                .backgroundImageUrl(user.getBackgroundImageUrl())
+                .nickname(user.getNickname())
+                .description(user.getDescription())
+                .followerCount(user.getFollowerCount())
+                .followingCount(user.getFollowingCount())
+                .isFirst(false)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,3 +68,7 @@ server:
   tomcat:
     mbeanregistry:
       enabled: true
+
+local-login:
+  id:
+  password:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -54,3 +54,7 @@ jwt:
   access-token-valid-time-unit: HOURS
   refresh-token-valid-time-duration: 1
   refresh-token-valid-time-unit: HOURS
+
+local-login:
+  id:
+  password:


### PR DESCRIPTION
# Description
로컬용 로그인 API를 구현했습니다.
계정은 환경변수를 통해 필드에 저장하고, 입력은 쿼리 파라미터를 통해 받습니다.
로그인에 성공하면 기존과 동일한 방식으로 응답을 내려줍니다.

다만, `Set-Cookie`에 토큰 값을 담을 때 Secure, httpOnly를 `false`, SameSite를 `None`로 설정해서 담습니다.

# Relation Issues
- close #262 
