### PR TITLE
feat: 관리자와 헷갈릴만한 닉네임은 허용하지 않도록 검증

### DIFF
--- a/src/main/java/com/listywave/common/exception/ErrorCode.java
+++ b/src/main/java/com/listywave/common/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     ELASTICSEARCH_REQUEST_FAILED(BAD_REQUEST, "Elasticsearch 검색 요청에 실패했습니다."),
 
     // Validation
+    ILLEGAL_NICKNAME_EXCEPTION(BAD_REQUEST, "사용 불가능한 닉네임입니다."),
     NICKNAME_CONTAINS_WHITESPACE_EXCEPTION(BAD_REQUEST, "닉네임의 처음과 마지막에 공백이 존재할 수 없습니다."),
     NICKNAME_CONTAINS_SPECIAL_CHARACTERS(BAD_REQUEST, "이모티콘 및 특수문자가 포함될 수 없습니다."),
     LENGTH_EXCEEDED_EXCEPTION(BAD_REQUEST, "최대 글자 길이를 초과하였습니다."),

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -163,7 +163,7 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public Boolean isDuplicateNickname(String nickname) {
-        return userRepository.existsByNicknameValue(nickname);
+        return userRepository.existsByNicknameValueIgnoreCase(nickname);
     }
 
     public void deleteFollower(Long followerUserId, Long followingUserId) {

--- a/src/main/java/com/listywave/user/application/vo/Nickname.java
+++ b/src/main/java/com/listywave/user/application/vo/Nickname.java
@@ -1,5 +1,6 @@
 package com.listywave.user.application.vo;
 
+import static com.listywave.common.exception.ErrorCode.ILLEGAL_NICKNAME_EXCEPTION;
 import static com.listywave.common.exception.ErrorCode.LENGTH_EXCEEDED_EXCEPTION;
 import static com.listywave.common.exception.ErrorCode.NICKNAME_CONTAINS_SPECIAL_CHARACTERS;
 import static com.listywave.common.exception.ErrorCode.NICKNAME_CONTAINS_WHITESPACE_EXCEPTION;
@@ -7,6 +8,8 @@ import static com.listywave.common.exception.ErrorCode.NICKNAME_CONTAINS_WHITESP
 import com.listywave.common.exception.CustomException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import java.util.Locale;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -19,6 +22,9 @@ import lombok.NoArgsConstructor;
 public class Nickname {
 
     private static final int LENGTH_LIMIT = 10;
+    private static final Set<String> BLACK_LIST = Set.of(
+            "운영자", "관리자", "admin", "listy", "L1sty", "에잇", "eight", "리스티"
+    );
 
     @Column(name = "nickname", unique = true, length = LENGTH_LIMIT, nullable = false)
     private final String value;
@@ -31,6 +37,7 @@ public class Nickname {
         validateBlank(value);
         validateLength(value);
         validateWord(value);
+        validateRelatedWithAdmin(value);
         return new Nickname(value);
     }
 
@@ -56,6 +63,15 @@ public class Nickname {
     private static void validateWord(String value) {
         if (!value.matches("[가-힣a-zA-Z]+")) {
             throw new CustomException(NICKNAME_CONTAINS_SPECIAL_CHARACTERS, "닉네임에는 숫자, 이모티콘, 특수문자가 포함될 수 없습니다.");
+        }
+    }
+
+    private static void validateRelatedWithAdmin(String value) {
+        value = value.toLowerCase(Locale.ENGLISH);
+        for (String word : BLACK_LIST) {
+            if (value.contains(word)) {
+                throw new CustomException(ILLEGAL_NICKNAME_EXCEPTION);
+            }
         }
     }
 }

--- a/src/main/java/com/listywave/user/application/vo/Nickname.java
+++ b/src/main/java/com/listywave/user/application/vo/Nickname.java
@@ -23,7 +23,8 @@ public class Nickname {
 
     private static final int LENGTH_LIMIT = 10;
     private static final Set<String> BLACK_LIST = Set.of(
-            "운영자", "관리자", "admin", "listy", "L1sty", "에잇", "eight", "리스티"
+            "운영자", "관리자", "admin", "listy", "L1sty", "에잇", "eight", "리스티", "관리인", "운영인", "관ㄹi자", "관ㄹl자",
+            "관ㄹI자", "관리ㅈr", "운영ㅈr", "관ㄹ1자", "adm1n", "관리요원"
     );
 
     @Column(name = "nickname", unique = true, length = LENGTH_LIMIT, nullable = false)

--- a/src/main/java/com/listywave/user/repository/user/UserRepository.java
+++ b/src/main/java/com/listywave/user/repository/user/UserRepository.java
@@ -27,7 +27,7 @@ public interface UserRepository extends JpaRepository<User, Long>, CustomUserRep
         throw new CustomException(RESOURCE_NOT_FOUND);
     }
 
-    Boolean existsByNicknameValue(String nickname);
+    Boolean existsByNicknameValueIgnoreCase(String nickname);
 
     @Override
     @Query("""

--- a/src/test/java/com/listywave/acceptance/user/UserAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/user/UserAcceptanceTest.java
@@ -134,6 +134,9 @@ public class UserAcceptanceTest extends AcceptanceTest {
 
         회원을_저장한다(동호());
         assertThat(닉네임_중복_체크_요청(동호().getNickname()).as(Boolean.class)).isTrue();
+
+        // 영어 대소문자를 구분한다.
+        assertThat(닉네임_중복_체크_요청("Kdkdhoho").as(Boolean.class)).isFalse();
     }
 
     @Test

--- a/src/test/java/com/listywave/acceptance/user/UserAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/user/UserAcceptanceTest.java
@@ -14,6 +14,7 @@ import static com.listywave.user.fixture.UserFixture.동호;
 import static com.listywave.user.fixture.UserFixture.유진;
 import static com.listywave.user.fixture.UserFixture.정수;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
@@ -130,13 +131,20 @@ public class UserAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 닉네임_중복을_체크한다() {
-        assertThat(닉네임_중복_체크_요청(동호().getNickname()).as(Boolean.class)).isFalse();
+        assertAll(
+                () -> assertThat(닉네임_중복_체크_요청(동호().getNickname()).as(Boolean.class)).isFalse(),
 
-        회원을_저장한다(동호());
-        assertThat(닉네임_중복_체크_요청(동호().getNickname()).as(Boolean.class)).isTrue();
+                () -> {
+                    회원을_저장한다(동호());
+                    assertThat(닉네임_중복_체크_요청(동호().getNickname()).as(Boolean.class)).isTrue();
+                },
 
-        // 영어 대소문자를 구분한다.
-        assertThat(닉네임_중복_체크_요청("Kdkdhoho").as(Boolean.class)).isFalse();
+                // 대소문자 구분없이 중복 체크
+                () -> assertThat(닉네임_중복_체크_요청("kdkdhoho").as(Boolean.class)).isTrue(),
+                () -> assertThat(닉네임_중복_체크_요청("KDKDHOHO").as(Boolean.class)).isTrue(),
+                () -> assertThat(닉네임_중복_체크_요청("KdkdHoho").as(Boolean.class)).isTrue()
+        );
+        ;
     }
 
     @Test

--- a/src/test/java/com/listywave/user/application/vo/NicknameTest.java
+++ b/src/test/java/com/listywave/user/application/vo/NicknameTest.java
@@ -46,7 +46,7 @@ class NicknameTest {
     @ValueSource(strings = {
             "listy", "ListyWave Official", "관리자", "운영자", "Admin", "시스템관리자", "Listywave관리자", "Listywave운영자",
             "ListyWaveOfficial", "리스티", "리스티웨이브관리자", "리스티웨이브운영자", "ADMIN", "admin", "팀 에잇", "EightOfficial",
-            "eight", "EIGHT"
+            "eight", "EIGHT", "관리인", "운영인", "관ㄹi자", "관ㄹI자", "관리ㅈr", "운영ㅈr", "관ㄹ1자", "adm1n", "관리요원"
     })
     void 관리자와_헷갈릴만한_닉네임은_생성할_수_없다(String input) {
         assertThatThrownBy(() -> Nickname.of(input));

--- a/src/test/java/com/listywave/user/application/vo/NicknameTest.java
+++ b/src/test/java/com/listywave/user/application/vo/NicknameTest.java
@@ -42,6 +42,16 @@ class NicknameTest {
         assertThatThrownBy(() -> Nickname.of("z1존도적"));
     }
 
+    @ParameterizedTest(name = "입력: {0}")
+    @ValueSource(strings = {
+            "listy", "ListyWave Official", "관리자", "운영자", "Admin", "시스템관리자", "Listywave관리자", "Listywave운영자",
+            "ListyWaveOfficial", "리스티", "리스티웨이브관리자", "리스티웨이브운영자", "ADMIN", "admin", "팀 에잇", "EightOfficial",
+            "eight", "EIGHT"
+    })
+    void 관리자와_헷갈릴만한_닉네임은_생성할_수_없다(String input) {
+        assertThatThrownBy(() -> Nickname.of(input));
+    }
+
     @Test
     void OauthId가_닉네임_최대_길이보다_긴_경우_최대_길이만큼_잘라_초기화한다() {
         Nickname nickname = Nickname.oauthIdOf("일이삼사오육칠팔구십일이삼사오");


### PR DESCRIPTION
# Description
1. 관리자와 헷갈릴만한 닉네임은 허용하지 않도록 검증하는 코드를 추가했습니다.
테스트 코드를 통해 모두 확인했습니다.
혹시나 추가로 걸러야 할 입력값이 있다면 알려주세요!
2. 닉네임에서 영어를 구분하는 현재 상황을 테스트 코드를 통해 확인했습니다.

# Relation Issues
- close #268 
