### PR TITLE
refactor: 트랜딩 TOP10 조회 API 정렬기준 변경

### DIFF
--- a/src/main/java/com/listywave/list/application/dto/response/ListTrandingResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/ListTrandingResponse.java
@@ -1,9 +1,7 @@
 package com.listywave.list.application.dto.response;
 
-import com.listywave.list.application.domain.list.ListEntity;
-import lombok.Builder;
+import com.listywave.list.application.domain.list.BackgroundColor;
 
-@Builder
 public record ListTrandingResponse(
         Long id,
         Long ownerId,
@@ -11,20 +9,25 @@ public record ListTrandingResponse(
         String ownerProfileImageUrl,
         String title,
         String description,
-        String itemImageUrl,
-        String backgroundColor
+        BackgroundColor backgroundColor,
+        Long trandingScore,
+        String itemImageUrl
 ) {
 
-    public static ListTrandingResponse of(ListEntity list) {
-        return ListTrandingResponse.builder()
-                .id(list.getId())
-                .ownerId(list.getUser().getId())
-                .ownerNickname(list.getUser().getNickname())
-                .ownerProfileImageUrl(list.getUser().getProfileImageUrl())
-                .title(list.getTitle().getValue())
-                .description(list.getDescription().getValue())
-                .itemImageUrl(list.getRepresentImageUrl())
-                .backgroundColor(list.getBackgroundColor().name())
-                .build();
+    public ListTrandingResponse(
+            Long id,
+            Long ownerId,
+            String ownerNickname,
+            String ownerProfileImageUrl,
+            String title,
+            String description,
+            BackgroundColor backgroundColor,
+            Long trandingScore
+    ) {
+        this(id, ownerId, ownerNickname, ownerProfileImageUrl, title, description, backgroundColor, trandingScore, "");
+    }
+
+    public ListTrandingResponse with(String imageUrl) {
+        return new ListTrandingResponse(id, ownerId, ownerNickname, ownerProfileImageUrl, title, description, backgroundColor, trandingScore, imageUrl);
     }
 }

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -149,8 +149,8 @@ public class ListService {
     }
 
     @Transactional(readOnly = true)
-    public List<ListTrandingResponse> getTrandingList() {
-        return listRepository.findTrandingLists();
+    public List<ListTrandingResponse> fetchTrandingLists() {
+        return listRepository.fetchTrandingLists();
     }
 
     public void deleteList(Long listId, Long loginUserId) {

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -150,10 +150,7 @@ public class ListService {
 
     @Transactional(readOnly = true)
     public List<ListTrandingResponse> getTrandingList() {
-        List<ListEntity> lists = listRepository.findTrandingLists();
-        return lists.stream()
-                .map(ListTrandingResponse::of)
-                .toList();
+        return listRepository.findTrandingLists();
     }
 
     public void deleteList(Long listId, Long loginUserId) {

--- a/src/main/java/com/listywave/list/presentation/controller/ListController.java
+++ b/src/main/java/com/listywave/list/presentation/controller/ListController.java
@@ -55,8 +55,8 @@ public class ListController {
     }
 
     @GetMapping("/lists/explore")
-    ResponseEntity<List<ListTrandingResponse>> getTrandingList() {
-        List<ListTrandingResponse> trandingList = listService.getTrandingList();
+    ResponseEntity<List<ListTrandingResponse>> fetchTrandingLists() {
+        List<ListTrandingResponse> trandingList = listService.fetchTrandingLists();
         return ResponseEntity.ok().body(trandingList);
     }
 

--- a/src/main/java/com/listywave/list/repository/list/custom/CustomListRepository.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/CustomListRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.Slice;
 
 public interface CustomListRepository {
 
-    List<ListTrandingResponse> findTrandingLists();
+    List<ListTrandingResponse> fetchTrandingLists();
 
     Slice<ListEntity> getRecentLists(LocalDateTime cursorUpdatedDate, Pageable pageable);
 

--- a/src/main/java/com/listywave/list/repository/list/custom/CustomListRepository.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/CustomListRepository.java
@@ -2,6 +2,7 @@ package com.listywave.list.repository.list.custom;
 
 import com.listywave.list.application.domain.category.CategoryType;
 import com.listywave.list.application.domain.list.ListEntity;
+import com.listywave.list.application.dto.response.ListTrandingResponse;
 import com.listywave.user.application.domain.User;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -10,7 +11,7 @@ import org.springframework.data.domain.Slice;
 
 public interface CustomListRepository {
 
-    List<ListEntity> findTrandingLists();
+    List<ListTrandingResponse> findTrandingLists();
 
     Slice<ListEntity> getRecentLists(LocalDateTime cursorUpdatedDate, Pageable pageable);
 

--- a/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
@@ -38,27 +38,11 @@ public class CustomListRepositoryImpl implements CustomListRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<ListTrandingResponse> findTrandingLists() {
+    public List<ListTrandingResponse> fetchTrandingLists() {
         List<ListTrandingResponse> responses = getTrandingResponses();
         return responses.stream()
                 .map(t -> t.with(getRepresentImageUrl(t.id())))
                 .collect(Collectors.toList());
-    }
-
-    private String getRepresentImageUrl(Long id) {
-        String imageUrl = queryFactory
-                .select(item.imageUrl.value)
-                .from(item)
-                .where(
-                        item.list.id.eq(id).and(
-                                item.imageUrl.value.ne("")
-                        )
-                )
-                .orderBy(item.ranking.asc())
-                .limit(1)
-                .fetchOne();
-
-        return imageUrl != null ? imageUrl : "";
     }
 
     private List<ListTrandingResponse> getTrandingResponses() {
@@ -95,6 +79,22 @@ public class CustomListRepositoryImpl implements CustomListRepository {
                 .orderBy(trandingScoreAlias.desc())
                 .limit(10)
                 .fetch();
+    }
+
+    private String getRepresentImageUrl(Long id) {
+        String imageUrl = queryFactory
+                .select(item.imageUrl.value)
+                .from(item)
+                .where(
+                        item.list.id.eq(id).and(
+                                item.imageUrl.value.ne("")
+                        )
+                )
+                .orderBy(item.ranking.asc())
+                .limit(1)
+                .fetchOne();
+
+        return imageUrl != null ? imageUrl : "";
     }
 
     @Override

--- a/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
@@ -5,20 +5,29 @@ import static com.listywave.collection.application.domain.QCollect.collect;
 import static com.listywave.common.exception.ErrorCode.NOT_SUPPORT_FILTER_ARGUMENT_EXCEPTION;
 import static com.listywave.common.util.PaginationUtils.checkEndPage;
 import static com.listywave.list.application.domain.category.CategoryType.ENTIRE;
+import static com.listywave.list.application.domain.comment.QComment.comment;
 import static com.listywave.list.application.domain.item.QItem.item;
 import static com.listywave.list.application.domain.label.QLabel.label;
 import static com.listywave.list.application.domain.list.QListEntity.listEntity;
+import static com.listywave.list.application.domain.reply.QReply.reply;
 import static com.listywave.user.application.domain.QUser.user;
+import static com.querydsl.jpa.JPAExpressions.select;
 
 import com.listywave.common.exception.CustomException;
 import com.listywave.list.application.domain.category.CategoryType;
 import com.listywave.list.application.domain.list.ListEntity;
+import com.listywave.list.application.dto.response.ListTrandingResponse;
 import com.listywave.list.repository.list.custom.CustomListRepository;
 import com.listywave.user.application.domain.User;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -29,21 +38,62 @@ public class CustomListRepositoryImpl implements CustomListRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<ListEntity> findTrandingLists() {
+    public List<ListTrandingResponse> findTrandingLists() {
+        List<ListTrandingResponse> responses = getTrandingResponses();
+        return responses.stream()
+                .map(t -> t.with(getRepresentImageUrl(t.id())))
+                .collect(Collectors.toList());
+    }
+
+    private String getRepresentImageUrl(Long id) {
+        String imageUrl = queryFactory
+                .select(item.imageUrl.value)
+                .from(item)
+                .where(
+                        item.list.id.eq(id).and(
+                                item.imageUrl.value.ne("")
+                        )
+                )
+                .orderBy(item.ranking.asc())
+                .limit(1)
+                .fetchOne();
+
+        return imageUrl != null ? imageUrl : "";
+    }
+
+    private List<ListTrandingResponse> getTrandingResponses() {
         LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+        NumberPath<Long> trandingScoreAlias = Expressions.numberPath(Long.class, "trandingScore");
 
         return queryFactory
-                .selectFrom(listEntity)
-                .join(listEntity.user, user).fetchJoin()
-                .leftJoin(item).on(listEntity.id.eq(item.list.id))
+                .select(Projections.constructor(ListTrandingResponse.class,
+                        listEntity.id.as("id"),
+                        listEntity.user.id.as("ownerId"),
+                        listEntity.user.nickname.value.as("ownerNickname"),
+                        listEntity.user.profileImageUrl.value.as("ownerProfileImageUrl"),
+                        listEntity.title.value.as("title"),
+                        listEntity.description.value.as("description"),
+                        listEntity.backgroundColor.as("backgroundColor"),
+                        ExpressionUtils.as(
+                                select(
+                                        listEntity.collectCount.multiply(3).add(
+                                                comment.countDistinct().add(reply.count()).multiply(2)
+                                        ).castToNum(Long.class)
+                                )
+                                        .from(comment)
+                                        .leftJoin(reply).on(reply.comment.id.eq(comment.id))
+                                        .where(comment.list.id.eq(listEntity.id)), trandingScoreAlias))
+                )
+                .from(listEntity)
+                .join(listEntity.user, user)
                 .where(
                         listEntity.updatedDate.goe(thirtyDaysAgo),
                         listEntity.isPublic.eq(true),
                         listEntity.user.isDelete.eq(false)
                 )
                 .distinct()
+                .orderBy(trandingScoreAlias.desc())
                 .limit(10)
-                .orderBy(listEntity.collectCount.desc(), listEntity.viewCount.desc(), listEntity.id.desc())
                 .fetch();
     }
 

--- a/src/test/java/com/listywave/acceptance/collection/CollectionAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/collection/CollectionAcceptanceTest.java
@@ -1,5 +1,110 @@
 package com.listywave.acceptance.collection;
 
-// TODO: 정수씨 테스트 부탁해요
-public class CollectionAcceptanceTest {
+import static com.listywave.acceptance.collection.CollectionAcceptanceTestHelper.나의_콜렉션_조회_API_호출;
+import static com.listywave.acceptance.collection.CollectionAcceptanceTestHelper.콜렉트_또는_콜렉트취소_API_호출;
+import static com.listywave.acceptance.collection.CollectionAcceptanceTestHelper.콜렉트_취소하기;
+import static com.listywave.acceptance.common.CommonAcceptanceHelper.HTTP_상태_코드를_검증한다;
+import static com.listywave.acceptance.list.ListAcceptanceTestHelper.가장_좋아하는_견종_TOP3_생성_요청_데이터;
+import static com.listywave.acceptance.list.ListAcceptanceTestHelper.리스트_저장_API_호출;
+import static com.listywave.acceptance.list.ListAcceptanceTestHelper.회원용_리스트_상세_조회_API_호출;
+import static com.listywave.list.fixture.ListFixture.지정된_개수만큼_리스트를_생성한다;
+import static com.listywave.user.fixture.UserFixture.동호;
+import static com.listywave.user.fixture.UserFixture.정수;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
+import com.listywave.acceptance.common.AcceptanceTest;
+import com.listywave.collection.application.dto.CollectionResponse;
+import com.listywave.collection.application.dto.CollectionResponse.CollectionListsResponse;
+import com.listywave.list.application.domain.list.ListEntity;
+import com.listywave.list.application.dto.response.ListCreateResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("콜렉션 관련 인수테스트")
+public class CollectionAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 타인의_리스트를_성공적으로_콜렉트한다() {
+        // given
+        var 동호 = 회원을_저장한다(동호());
+        var 정수 = 회원을_저장한다(정수());
+        var 정수_엑세스_토큰 = 액세스_토큰을_발급한다(정수);
+        var 동호_엑세스_토큰 = 액세스_토큰을_발급한다(동호);
+        var 리스트_생성_요청_데이터 = 가장_좋아하는_견종_TOP3_생성_요청_데이터(List.of());
+        리스트_저장_API_호출(리스트_생성_요청_데이터, 정수_엑세스_토큰).as(ListCreateResponse.class);
+
+        // when
+        var 응답 = 콜렉트_또는_콜렉트취소_API_호출(동호_엑세스_토큰, 1L);
+        var 정수_리스트_콜렉트수 = 회원용_리스트_상세_조회_API_호출(정수_엑세스_토큰, 1L).collectCount();
+
+        // then
+        HTTP_상태_코드를_검증한다(응답, NO_CONTENT);
+        assertThat(정수_리스트_콜렉트수).isEqualTo(1);
+    }
+
+    @Test
+    void 나의_리스트는_콜렉트할_수_없다() {
+        // given
+        var 정수 = 회원을_저장한다(정수());
+        var 정수_엑세스_토큰 = 액세스_토큰을_발급한다(정수);
+        var 리스트_생성_요청_데이터 = 가장_좋아하는_견종_TOP3_생성_요청_데이터(List.of());
+        리스트_저장_API_호출(리스트_생성_요청_데이터, 정수_엑세스_토큰);
+
+        // when
+        var 응답 = 콜렉트_또는_콜렉트취소_API_호출(정수_엑세스_토큰, 1L);
+        var 정수_리스트_콜렉트수 = 회원용_리스트_상세_조회_API_호출(정수_엑세스_토큰, 1L).collectCount();
+
+        // then
+        HTTP_상태_코드를_검증한다(응답, FORBIDDEN);
+        assertThat(정수_리스트_콜렉트수).isEqualTo(0);
+    }
+
+    @Test
+    void 콜렉트션에_담긴_리스트를_콜렉트_취소한다() {
+        // given
+        var 동호 = 회원을_저장한다(동호());
+        var 정수 = 회원을_저장한다(정수());
+        var 정수_엑세스_토큰 = 액세스_토큰을_발급한다(정수);
+        var 동호_엑세스_토큰 = 액세스_토큰을_발급한다(동호);
+        var 리스트_생성_요청_데이터 = 가장_좋아하는_견종_TOP3_생성_요청_데이터(List.of());
+        리스트_저장_API_호출(리스트_생성_요청_데이터, 정수_엑세스_토큰).as(ListCreateResponse.class);
+
+        // when
+        var 응답_리스트 = 콜렉트_취소하기(동호_엑세스_토큰, 1L);
+        var 정수_리스트_콜렉트수 = 회원용_리스트_상세_조회_API_호출(정수_엑세스_토큰, 1L).collectCount();
+
+        // then
+        응답_리스트.forEach(응답 -> HTTP_상태_코드를_검증한다(응답, NO_CONTENT));
+        assertThat(정수_리스트_콜렉트수).isEqualTo(0);
+    }
+
+    @Test
+    void 나의_콜렉션을_조회한다() {
+        // given
+        var 동호 = 회원을_저장한다(동호());
+        var 정수 = 회원을_저장한다(정수());
+        var 정수_엑세스_토큰 = 액세스_토큰을_발급한다(정수);
+        var 동호_엑세스_토큰 = 액세스_토큰을_발급한다(동호);
+        var 생성한_리스트 = 지정된_개수만큼_리스트를_생성한다(동호, 2);
+        리스트를_모두_저장한다(생성한_리스트);
+
+        콜렉트_또는_콜렉트취소_API_호출(정수_엑세스_토큰, 1L);
+        콜렉트_또는_콜렉트취소_API_호출(정수_엑세스_토큰, 2L);
+
+        // when
+        var 결과 = 나의_콜렉션_조회_API_호출(정수_엑세스_토큰, "entire")
+                .as(CollectionResponse.class)
+                .collectionLists().stream()
+                .map(CollectionListsResponse::list)
+                .collect(Collectors.toList());
+
+        // then
+        assertThat(결과).usingRecursiveComparison()
+                .comparingOnlyFields("id")
+                .isEqualTo(생성한_리스트.stream().map(ListEntity::getId).toList());
+    }
 }

--- a/src/test/java/com/listywave/acceptance/collection/CollectionAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/collection/CollectionAcceptanceTest.java
@@ -2,7 +2,6 @@ package com.listywave.acceptance.collection;
 
 import static com.listywave.acceptance.collection.CollectionAcceptanceTestHelper.나의_콜렉션_조회_API_호출;
 import static com.listywave.acceptance.collection.CollectionAcceptanceTestHelper.콜렉트_또는_콜렉트취소_API_호출;
-import static com.listywave.acceptance.collection.CollectionAcceptanceTestHelper.콜렉트_취소하기;
 import static com.listywave.acceptance.common.CommonAcceptanceHelper.HTTP_상태_코드를_검증한다;
 import static com.listywave.acceptance.list.ListAcceptanceTestHelper.가장_좋아하는_견종_TOP3_생성_요청_데이터;
 import static com.listywave.acceptance.list.ListAcceptanceTestHelper.리스트_저장_API_호출;
@@ -43,7 +42,7 @@ public class CollectionAcceptanceTest extends AcceptanceTest {
 
         // then
         HTTP_상태_코드를_검증한다(응답, NO_CONTENT);
-        assertThat(정수_리스트_콜렉트수).isEqualTo(1);
+        assertThat(정수_리스트_콜렉트수).isOne();
     }
 
     @Test
@@ -60,11 +59,11 @@ public class CollectionAcceptanceTest extends AcceptanceTest {
 
         // then
         HTTP_상태_코드를_검증한다(응답, FORBIDDEN);
-        assertThat(정수_리스트_콜렉트수).isEqualTo(0);
+        assertThat(정수_리스트_콜렉트수).isZero();
     }
 
     @Test
-    void 콜렉트션에_담긴_리스트를_콜렉트_취소한다() {
+    void 콜렉션에_담긴_리스트를_콜렉트_취소한다() {
         // given
         var 동호 = 회원을_저장한다(동호());
         var 정수 = 회원을_저장한다(정수());
@@ -74,11 +73,13 @@ public class CollectionAcceptanceTest extends AcceptanceTest {
         리스트_저장_API_호출(리스트_생성_요청_데이터, 정수_엑세스_토큰).as(ListCreateResponse.class);
 
         // when
-        var 응답_리스트 = 콜렉트_취소하기(동호_엑세스_토큰, 1L);
+        var 콜렉트_하기_응답 = 콜렉트_또는_콜렉트취소_API_호출(동호_엑세스_토큰, 1L);
+        var 콜렉트_취소_응답 = 콜렉트_또는_콜렉트취소_API_호출(동호_엑세스_토큰, 1L);
         var 정수_리스트_콜렉트수 = 회원용_리스트_상세_조회_API_호출(정수_엑세스_토큰, 1L).collectCount();
 
         // then
-        응답_리스트.forEach(응답 -> HTTP_상태_코드를_검증한다(응답, NO_CONTENT));
+        HTTP_상태_코드를_검증한다(콜렉트_하기_응답, NO_CONTENT);
+        HTTP_상태_코드를_검증한다(콜렉트_취소_응답, NO_CONTENT);
         assertThat(정수_리스트_콜렉트수).isEqualTo(0);
     }
 
@@ -88,7 +89,6 @@ public class CollectionAcceptanceTest extends AcceptanceTest {
         var 동호 = 회원을_저장한다(동호());
         var 정수 = 회원을_저장한다(정수());
         var 정수_엑세스_토큰 = 액세스_토큰을_발급한다(정수);
-        var 동호_엑세스_토큰 = 액세스_토큰을_발급한다(동호);
         var 생성한_리스트 = 지정된_개수만큼_리스트를_생성한다(동호, 2);
         리스트를_모두_저장한다(생성한_리스트);
 

--- a/src/test/java/com/listywave/acceptance/collection/CollectionAcceptanceTestHelper.java
+++ b/src/test/java/com/listywave/acceptance/collection/CollectionAcceptanceTestHelper.java
@@ -26,10 +26,4 @@ public abstract class CollectionAcceptanceTestHelper {
                 .then().log().all()
                 .extract();
     }
-
-    public static List<ExtractableResponse<Response>> 콜렉트_취소하기(String accessToken, Long listId) {
-        return IntStream.range(0, 2)
-                .mapToObj(i -> 콜렉트_또는_콜렉트취소_API_호출(accessToken, listId))
-                .collect(Collectors.toList());
-    }
 }

--- a/src/test/java/com/listywave/acceptance/collection/CollectionAcceptanceTestHelper.java
+++ b/src/test/java/com/listywave/acceptance/collection/CollectionAcceptanceTestHelper.java
@@ -1,0 +1,35 @@
+package com.listywave.acceptance.collection;
+
+import static com.listywave.acceptance.common.CommonAcceptanceHelper.given;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public abstract class CollectionAcceptanceTestHelper {
+
+    public static ExtractableResponse<Response> 콜렉트_또는_콜렉트취소_API_호출(String accessToken, Long listId) {
+        return given()
+                .header(AUTHORIZATION, "Bearer " + accessToken)
+                .when().post("/lists/{listId}/collect", listId)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 나의_콜렉션_조회_API_호출(String accessToken, String category) {
+        return given()
+                .header(AUTHORIZATION, "Bearer " + accessToken)
+                .when().get("/lists/collect?category={category}", category)
+                .then().log().all()
+                .extract();
+    }
+
+    public static List<ExtractableResponse<Response>> 콜렉트_취소하기(String accessToken, Long listId) {
+        return IntStream.range(0, 2)
+                .mapToObj(i -> 콜렉트_또는_콜렉트취소_API_호출(accessToken, listId))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -1,5 +1,8 @@
 package com.listywave.acceptance.list;
 
+import static com.listywave.acceptance.collection.CollectionAcceptanceTestHelper.콜렉트_또는_콜렉트취소_API_호출;
+import static com.listywave.acceptance.comment.CommentAcceptanceTestHelper.n개의_댓글_생성_요청;
+import static com.listywave.acceptance.comment.CommentAcceptanceTestHelper.댓글_저장_API_호출;
 import static com.listywave.acceptance.common.CommonAcceptanceHelper.HTTP_상태_코드를_검증한다;
 import static com.listywave.acceptance.follow.FollowAcceptanceTestHelper.팔로우_요청_API;
 import static com.listywave.acceptance.list.ListAcceptanceTestHelper.가장_좋아하는_견종_TOP3_생성_요청_데이터;
@@ -11,7 +14,7 @@ import static com.listywave.acceptance.list.ListAcceptanceTestHelper.리스트_�
 import static com.listywave.acceptance.list.ListAcceptanceTestHelper.리스트의_아이템_순위와_히스토리의_아이템_순위를_검증한다;
 import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원_리스트_상세_조회_API_호출;
 import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원_최신_리스트_10개_조회_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원_피드_리스트_조회;
+import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원_피드_리스트_조회_API_호출;
 import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원_히스토리_조회_API_호출;
 import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원이_피드_리스트_조회_카테고리_콜라보레이터_필터링_요청;
 import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원이_피드_리스트_조회_카테고리_필터링_요청;
@@ -28,6 +31,7 @@ import static com.listywave.acceptance.list.ListAcceptanceTestHelper.트랜딩_�
 import static com.listywave.acceptance.list.ListAcceptanceTestHelper.회원_최신_리스트_10개_조회_API_호출;
 import static com.listywave.acceptance.list.ListAcceptanceTestHelper.회원_피드_리스트_조회;
 import static com.listywave.acceptance.list.ListAcceptanceTestHelper.회원용_리스트_상세_조회_API_호출;
+import static com.listywave.acceptance.reply.ReplyAcceptanceTestHelper.답글_등록_API_호출;
 import static com.listywave.list.fixture.ListFixture.가장_좋아하는_견종_TOP3;
 import static com.listywave.list.fixture.ListFixture.가장_좋아하는_견종_TOP3_순위_변경;
 import static com.listywave.list.fixture.ListFixture.좋아하는_라면_TOP3;
@@ -62,11 +66,13 @@ import com.listywave.list.application.dto.response.ListSearchResponse;
 import com.listywave.list.application.dto.response.ListTrandingResponse;
 import com.listywave.list.presentation.dto.request.ItemCreateRequest;
 import com.listywave.list.presentation.dto.request.ListUpdateRequest;
+import com.listywave.list.presentation.dto.request.ReplyCreateRequest;
 import com.listywave.user.application.dto.FindFeedListResponse;
 import com.listywave.user.application.dto.FindFeedListResponse.FeedListInfo;
 import com.listywave.user.application.dto.FindFeedListResponse.ListItemsResponse;
 import io.restassured.common.mapper.TypeRef;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -441,7 +447,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
             var 동호_리스트_2 = 리스트를_저장한다(좋아하는_라면_TOP3(동호, List.of()));
 
             // when
-            var 결과 = 비회원_피드_리스트_조회(동호).as(FindFeedListResponse.class);
+            var 결과 = 비회원_피드_리스트_조회_API_호출(동호).as(FindFeedListResponse.class);
             var 기대값 = List.of(FeedListInfo.of(동호_리스트_2), FeedListInfo.of(동호_리스트_1));
 
             // then
@@ -565,17 +571,30 @@ public class ListAcceptanceTest extends AcceptanceTest {
             // given
             var 동호 = 회원을_저장한다(동호());
             var 정수 = 회원을_저장한다(정수());
+            var 동호_액세스_토큰 = 액세스_토큰을_발급한다(동호);
+            var 정수_액세스_토큰 = 액세스_토큰을_발급한다(정수);
             리스트를_모두_저장한다(지정된_개수만큼_리스트를_생성한다(동호, 5));
             리스트를_모두_저장한다(지정된_개수만큼_리스트를_생성한다(정수, 5));
             리스트를_모두_저장한다(지정된_개수만큼_리스트를_생성한다(동호, 5));
+
+            var 댓글_생성_요청들 = n개의_댓글_생성_요청(4);
+            var 댓글_생성_요청들2 = n개의_댓글_생성_요청(8);
+            댓글_생성_요청들.forEach(댓글_생성요청 -> 댓글_저장_API_호출(동호_액세스_토큰, 2L, 댓글_생성요청));
+            댓글_생성_요청들2.forEach(댓글_생성요청 -> 댓글_저장_API_호출(동호_액세스_토큰, 4L, 댓글_생성요청));
+
+            var 답글_생성_요청들 = Arrays.asList(new ReplyCreateRequest("답글1"), new ReplyCreateRequest("답글2"));
+            답글_생성_요청들.forEach(답글_생성요청 -> 답글_등록_API_호출(동호_액세스_토큰, 답글_생성요청, 2L, 2L));
+
+            콜렉트_또는_콜렉트취소_API_호출(정수_액세스_토큰, 2L);
+            콜렉트_또는_콜렉트취소_API_호출(동호_액세스_토큰, 7L);
 
             // when
             List<ListTrandingResponse> 결과 = 트랜딩_리스트_조회_API_호출().as(new TypeRef<>() {
             });
 
             // then
-            var 동호_리스트 = 비회원_피드_리스트_조회(동호).as(FindFeedListResponse.class).feedLists();
-            var 정수_리스트 = 비회원_피드_리스트_조회(정수).as(FindFeedListResponse.class).feedLists();
+            var 동호_리스트 = 비회원_피드_리스트_조회_API_호출(동호).as(FindFeedListResponse.class).feedLists();
+            var 정수_리스트 = 비회원_피드_리스트_조회_API_호출(정수).as(FindFeedListResponse.class).feedLists();
             var 모든_리스트 = new ArrayList<>(동호_리스트);
             모든_리스트.addAll(정수_리스트);
 
@@ -589,14 +608,14 @@ public class ListAcceptanceTest extends AcceptanceTest {
                             .orElse(""))
                     .toList();
 
-            assertThat(결과.stream().map(ListTrandingResponse::id)).isEqualTo(모든_리스트.stream()
-                    .sorted(comparing(FeedListInfo::id, reverseOrder()))
-                    .map(FeedListInfo::id)
-                    .limit(10)
-                    .toList());
-            assertThat(결과).usingRecursiveComparison()
-                    .comparingOnlyFields("itemImageUrl")
-                    .isEqualTo(대표_이미지들);
+            assertAll(
+                    () -> assertThat(결과).usingRecursiveComparison()
+                            .comparingOnlyFields("itemImageUrl")
+                            .isEqualTo(대표_이미지들),
+                    () -> assertThat(결과.get(0).trandingScore()).isEqualTo(16),
+                    () -> assertThat(결과.get(1).trandingScore()).isEqualTo(15),
+                    () -> assertThat(결과.get(2).trandingScore()).isEqualTo(3)
+            );
         }
 
         @Test
@@ -633,8 +652,8 @@ public class ListAcceptanceTest extends AcceptanceTest {
             var 결과 = 비회원_최신_리스트_10개_조회_API_호출().as(ListRecentResponse.class);
 
             // then
-            var 동호_리스트 = 비회원_피드_리스트_조회(동호).as(FindFeedListResponse.class).feedLists();
-            var 정수_리스트 = 비회원_피드_리스트_조회(정수).as(FindFeedListResponse.class).feedLists();
+            var 동호_리스트 = 비회원_피드_리스트_조회_API_호출(동호).as(FindFeedListResponse.class).feedLists();
+            var 정수_리스트 = 비회원_피드_리스트_조회_API_호출(정수).as(FindFeedListResponse.class).feedLists();
             var 모든_리스트 = new ArrayList<>(동호_리스트);
             모든_리스트.addAll(정수_리스트);
 

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTestHelper.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTestHelper.java
@@ -141,7 +141,7 @@ public abstract class ListAcceptanceTestHelper {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 비회원_피드_리스트_조회(User user) {
+    public static ExtractableResponse<Response> 비회원_피드_리스트_조회_API_호출(User user) {
         return given()
                 .when().get("/users/{userId}/lists", user.getId())
                 .then().log().all()
@@ -249,4 +249,3 @@ public abstract class ListAcceptanceTestHelper {
                 .extract();
     }
 }
-

--- a/src/test/java/com/listywave/acceptance/reply/ReplyAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/reply/ReplyAcceptanceTest.java
@@ -38,8 +38,8 @@ public class ReplyAcceptanceTest extends AcceptanceTest {
         댓글_생성_요청들.forEach(댓글_생성요청 -> 댓글_저장_API_호출(동호_액세스_토큰, 동호_리스트.getId(), 댓글_생성요청));
 
         // when
-        var 답글_수정_요청 = new ReplyCreateRequest("답글 달아요! 😀 ");
-        답글_등록_API_호출(동호_액세스_토큰, 답글_수정_요청, 동호_리스트.getId(), 2L);
+        var 답글_생성_요청 = new ReplyCreateRequest("답글 달아요! 😀 ");
+        답글_등록_API_호출(동호_액세스_토큰, 답글_생성_요청, 동호_리스트.getId(), 2L);
 
         // then
         var 결과 = 댓글_조회_API_호출(동호_리스트.getId()).as(CommentFindResponse.class);
@@ -163,7 +163,7 @@ public class ReplyAcceptanceTest extends AcceptanceTest {
 
             // then
             var 결과 = 댓글_조회_API_호출(동호_리스트.getId()).as(CommentFindResponse.class);
-            
+
             assertThat(결과.totalCount()).isEqualTo(2);
             assertThat(결과.comments().get(0).id()).isEqualTo(1);
             assertThat(결과.comments().get(1).id()).isEqualTo(3);


### PR DESCRIPTION
# Description
**탐색 페이지 트랜딩 리스트 TOP10 API의 정렬기준을 변경하였습니다.**
_-> 정렬기준 :  ((댓글+답글) * 2) + (콜렉션수 * 3) 높은순 10개_   

🤣 어떻게든간에 하나의 쿼리로 가져오려고 노력을 해보았지만... 해당 리스트에 아이템들중 순위가 가장 높은 아이템의 imageUrl 1개 가져오거나 imageUrl이 없으면 빈공백을 가져오는 파트 부분을 서브쿼리로 하려 했지만 QueryDsl은 subQuery에 limit이 먹지 않는 말도안되는 이슈가 있어서 발악 실패로 결국 별도에 쿼리로 매칭하면서 가져옴
**_-> 더 좋은 방안이 있는지 곰곰이 생각해 봐도 떠오르질 않아서 이게 최선의 방법이였음 .. ( 있다면 추천 해줘요 동호씌 )_**


**한김에 Collection 부분 테스트코드도 구현했습니다!**

# Relation Issues
- close #276 
