### PR TITLE
refactor: 내 피드 리스트 공개 상태 여부 정책 변경에 따른 API 수정

### DIFF
--- a/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
+++ b/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
@@ -229,8 +229,8 @@ public class ListEntity {
         }
     }
 
-    public void updateVisibility(Boolean isPublic) {
-        this.isPublic = isPublic;
+    public void updateVisibility() {
+        this.isPublic = !this.isPublic;
     }
 
     public String getRepresentImageUrl() {

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -304,4 +304,11 @@ public class ListService {
         }
         return FindFeedListResponse.of(result.hasNext(), cursorUpdatedDate, lists);
     }
+
+    public void changeVisibility(Long loginUserId, Long listId) {
+        User user = userRepository.getById(loginUserId);
+        ListEntity list = listRepository.getById(listId);
+        list.validateOwner(user);
+        list.updateVisibility();
+    }
 }

--- a/src/main/java/com/listywave/list/presentation/controller/ListController.java
+++ b/src/main/java/com/listywave/list/presentation/controller/ListController.java
@@ -120,7 +120,7 @@ public class ListController {
             @RequestBody ListsDeleteRequest request
     ) {
         listService.deleteLists(userId, request.listId());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @PatchMapping("/lists/{listId}/visibility")
@@ -129,6 +129,6 @@ public class ListController {
             @PathVariable("listId") Long listId
     ) {
         listService.changeVisibility(loginUserId, listId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/listywave/list/presentation/controller/ListController.java
+++ b/src/main/java/com/listywave/list/presentation/controller/ListController.java
@@ -122,4 +122,13 @@ public class ListController {
         listService.deleteLists(userId, request.listId());
         return ResponseEntity.ok().build();
     }
+
+    @PatchMapping("/lists/{listId}/visibility")
+    ResponseEntity<Void> changeVisibility(
+            @Auth Long loginUserId,
+            @PathVariable("listId") Long listId
+    ) {
+        listService.changeVisibility(loginUserId, listId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -36,7 +36,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserService {
 
-    private final ListRepository listRepository;
     private final UserRepository userRepository;
     private final FollowRepository followRepository;
     private final UserElasticRepository userElasticRepository;
@@ -173,14 +172,6 @@ public class UserService {
         followRepository.deleteByFollowingUserAndFollowerUser(followingUser, followerUser);
 
         followingUser.remove(followerUser);
-    }
-
-    public void updateListVisibility(Long loginUserId, Long listId, Boolean isPublic) {
-        User user = userRepository.getById(loginUserId);
-        ListEntity list = listRepository.getById(listId);
-        list.validateOwner(user);
-
-        list.updateVisibility(isPublic);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -175,12 +175,12 @@ public class UserService {
         followingUser.remove(followerUser);
     }
 
-    public void updateListVisibility(Long loginUserId, Long listId, Boolean beforeIsPublic) {
+    public void updateListVisibility(Long loginUserId, Long listId, Boolean isPublic) {
         User user = userRepository.getById(loginUserId);
         ListEntity list = listRepository.getById(listId);
         list.validateOwner(user);
 
-        list.updateVisibility(!beforeIsPublic);
+        list.updateVisibility(isPublic);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/listywave/user/presentation/UserController.java
+++ b/src/main/java/com/listywave/user/presentation/UserController.java
@@ -122,15 +122,6 @@ public class UserController {
         return ResponseEntity.noContent().build();
     }
 
-    @PatchMapping("/users/list-visibility")
-    ResponseEntity<Void> updateListVisibility(
-            @Auth Long loginUserId,
-            @RequestBody ListVisibilityUpdateRequest request
-    ) {
-        userService.updateListVisibility(loginUserId, request.listId(), request.isPublic());
-        return ResponseEntity.ok().build();
-    }
-
     @GetMapping("/v2/users")
     ResponseEntity<UserElasticSearchResponse> searchUserByElastic(
             @OptionalAuth Long loginUserId,

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -5,32 +5,7 @@ import static com.listywave.acceptance.comment.CommentAcceptanceTestHelper.n개�
 import static com.listywave.acceptance.comment.CommentAcceptanceTestHelper.댓글_저장_API_호출;
 import static com.listywave.acceptance.common.CommonAcceptanceHelper.HTTP_상태_코드를_검증한다;
 import static com.listywave.acceptance.follow.FollowAcceptanceTestHelper.팔로우_요청_API;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.가장_좋아하는_견종_TOP3_생성_요청_데이터;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.검색_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.리스트_삭제_요청_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.리스트_상세_조회를_검증한다;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.리스트_수정_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.리스트_저장_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.리스트의_아이템_순위와_히스토리의_아이템_순위를_검증한다;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원_리스트_상세_조회_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원_최신_리스트_10개_조회_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원_피드_리스트_조회_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원_히스토리_조회_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원이_피드_리스트_조회_카테고리_콜라보레이터_필터링_요청;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원이_피드_리스트_조회_카테고리_필터링_요청;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원이_피드_리스트_조회_콜라보레이터_필터링_요청;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.아이템_순위와_라벨을_바꾼_좋아하는_견종_TOP3_요청_데이터;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.정렬기준을_포함한_검색_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.좋아하는_라면_TOP3_생성_요청_데이터;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.카테고리로_검색_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.카테고리와_키워드로_검색_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.콜렉트_요청_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.키워드로_검색_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.키워드와_정렬기준을_포함한_검색_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.트랜딩_리스트_조회_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.회원_최신_리스트_10개_조회_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.회원_피드_리스트_조회;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.회원용_리스트_상세_조회_API_호출;
+import static com.listywave.acceptance.list.ListAcceptanceTestHelper.*;
 import static com.listywave.acceptance.reply.ReplyAcceptanceTestHelper.답글_등록_API_호출;
 import static com.listywave.list.fixture.ListFixture.가장_좋아하는_견종_TOP3;
 import static com.listywave.list.fixture.ListFixture.가장_좋아하는_견종_TOP3_순위_변경;
@@ -45,12 +20,8 @@ import static java.util.Comparator.reverseOrder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.FORBIDDEN;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.NO_CONTENT;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.OK;
 
 import com.listywave.acceptance.common.AcceptanceTest;
 import com.listywave.auth.infra.kakao.response.KakaoLogoutResponse;
@@ -815,6 +786,65 @@ public class ListAcceptanceTest extends AcceptanceTest {
                     () -> assertThat(결과.resultLists()).hasSize(1),
                     () -> assertThat(결과.resultLists().get(0).id()).isEqualTo(좋아하는_라면_TOP3_생성_결과.listId())
             );
+        }
+    }
+
+    @Nested
+    class 피드에서_내_리스트_공개_여부_설정 {
+
+        @Test
+        void 내_피드의_공개_리스트_비공개로_설정() {
+            // given
+            var 정수 = 회원을_저장한다(정수());
+            var 정수_액세스_토큰 = 액세스_토큰을_발급한다(정수);
+            var 정수_리스트_ID = 리스트_저장_API_호출(가장_좋아하는_견종_TOP3_생성_요청_데이터(List.of()), 정수_액세스_토큰)
+                    .as(ListCreateResponse.class)
+                    .listId();
+
+            // when
+            var 응답 = 리스트_공개_여부_변경_API_호출(정수_액세스_토큰, 정수_리스트_ID);
+            var 수정_이후_리스트_공개_여부_조회_결과 = 회원용_리스트_상세_조회_API_호출(정수_액세스_토큰, 정수_리스트_ID);
+
+            // then
+            HTTP_상태_코드를_검증한다(응답, OK);
+            assertThat(수정_이후_리스트_공개_여부_조회_결과.isPublic()).isFalse();
+        }
+
+        @Test
+        void 내_피드의_비공개_리스트_공개로_설정() {
+            // given
+            var 정수 = 회원을_저장한다(정수());
+            var 정수_액세스_토큰 = 액세스_토큰을_발급한다(정수);
+            var 정수_리스트_ID = 리스트_저장_API_호출(가장_좋아하는_견종_TOP3_생성_요청_데이터(List.of()), 정수_액세스_토큰)
+                    .as(ListCreateResponse.class)
+                    .listId();
+            리스트_공개_여부_변경_API_호출(정수_액세스_토큰, 정수_리스트_ID);
+
+            // when
+            var 응답 = 리스트_공개_여부_변경_API_호출(정수_액세스_토큰, 정수_리스트_ID);
+            var 수정_이후_리스트_공개_여부_조회_결과 = 회원용_리스트_상세_조회_API_호출(정수_액세스_토큰, 정수_리스트_ID);
+
+            // then
+            HTTP_상태_코드를_검증한다(응답, OK);
+            assertThat(수정_이후_리스트_공개_여부_조회_결과.isPublic()).isTrue();
+        }
+
+        @Test
+        void 내_피드가_아닌_리스트는_공개_여부_설정을_할_수_없다() {
+            // given
+            var 정수 = 회원을_저장한다(정수());
+            var 동호 = 회원을_저장한다(동호());
+            var 정수_액세스_토큰 = 액세스_토큰을_발급한다(정수);
+            var 동호_액세스_토큰 = 액세스_토큰을_발급한다(동호);
+            var 동호_리스트_ID = 리스트_저장_API_호출(가장_좋아하는_견종_TOP3_생성_요청_데이터(List.of()), 동호_액세스_토큰)
+                    .as(ListCreateResponse.class)
+                    .listId();
+
+            // when
+            var 응답 = 리스트_공개_여부_변경_API_호출(정수_액세스_토큰, 동호_리스트_ID);
+
+            // then
+            HTTP_상태_코드를_검증한다(응답, FORBIDDEN);
         }
     }
 }

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -790,10 +790,10 @@ public class ListAcceptanceTest extends AcceptanceTest {
     }
 
     @Nested
-    class 피드에서_내_리스트_공개_여부_설정 {
+    class 내_리스트_공개_여부_설정 {
 
         @Test
-        void 내_피드의_공개_리스트_비공개로_설정() {
+        void 내_공개_리스트_비공개로_설정() {
             // given
             var 정수 = 회원을_저장한다(정수());
             var 정수_액세스_토큰 = 액세스_토큰을_발급한다(정수);
@@ -806,12 +806,12 @@ public class ListAcceptanceTest extends AcceptanceTest {
             var 수정_이후_리스트_공개_여부_조회_결과 = 회원용_리스트_상세_조회_API_호출(정수_액세스_토큰, 정수_리스트_ID);
 
             // then
-            HTTP_상태_코드를_검증한다(응답, OK);
+            HTTP_상태_코드를_검증한다(응답, NO_CONTENT);
             assertThat(수정_이후_리스트_공개_여부_조회_결과.isPublic()).isFalse();
         }
 
         @Test
-        void 내_피드의_비공개_리스트_공개로_설정() {
+        void 내_비공개_리스트_공개로_설정() {
             // given
             var 정수 = 회원을_저장한다(정수());
             var 정수_액세스_토큰 = 액세스_토큰을_발급한다(정수);
@@ -825,12 +825,12 @@ public class ListAcceptanceTest extends AcceptanceTest {
             var 수정_이후_리스트_공개_여부_조회_결과 = 회원용_리스트_상세_조회_API_호출(정수_액세스_토큰, 정수_리스트_ID);
 
             // then
-            HTTP_상태_코드를_검증한다(응답, OK);
+            HTTP_상태_코드를_검증한다(응답, NO_CONTENT);
             assertThat(수정_이후_리스트_공개_여부_조회_결과.isPublic()).isTrue();
         }
 
         @Test
-        void 내_피드가_아닌_리스트는_공개_여부_설정을_할_수_없다() {
+        void 내_리스트가_아니면_공개_여부_설정을_할_수_없다() {
             // given
             var 정수 = 회원을_저장한다(정수());
             var 동호 = 회원을_저장한다(동호());

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTestHelper.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTestHelper.java
@@ -249,10 +249,7 @@ public abstract class ListAcceptanceTestHelper {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 리스트_공개_여부_변경_API_호출(
-            String accessToken,
-            Long listId
-    ) {
+    public static ExtractableResponse<Response> 리스트_공개_여부_변경_API_호출(String accessToken, Long listId) {
         return given()
                 .header(AUTHORIZATION, "Bearer " + accessToken)
                 .when().patch("/lists/{listId}/visibility", listId)

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTestHelper.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTestHelper.java
@@ -248,4 +248,15 @@ public abstract class ListAcceptanceTestHelper {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 리스트_공개_여부_변경_API_호출(
+            String accessToken,
+            Long listId
+    ) {
+        return given()
+                .header(AUTHORIZATION, "Bearer " + accessToken)
+                .when().patch("/lists/{listId}/visibility", listId)
+                .then().log().all()
+                .extract();
+    }
 }

--- a/src/test/java/com/listywave/acceptance/user/UserAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/user/UserAcceptanceTest.java
@@ -2,9 +2,7 @@ package com.listywave.acceptance.user;
 
 import static com.listywave.acceptance.common.CommonAcceptanceHelper.HTTP_상태_코드를_검증한다;
 import static com.listywave.acceptance.follow.FollowAcceptanceTestHelper.팔로우_요청_API;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.*;
 import static com.listywave.acceptance.user.UserAcceptanceTestHelper.*;
-import static com.listywave.acceptance.user.UserAcceptanceTestHelper.내_피드_리스트_공개_여부_설정_API_호출;
 import static com.listywave.user.fixture.UserFixture.동호;
 import static com.listywave.user.fixture.UserFixture.유진;
 import static com.listywave.user.fixture.UserFixture.정수;
@@ -13,11 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.http.HttpStatus.*;
 
 import com.listywave.acceptance.common.AcceptanceTest;
-import com.listywave.list.application.dto.response.ListCreateResponse;
 import com.listywave.user.application.dto.RecommendUsersResponse;
 import com.listywave.user.application.dto.UserInfoResponse;
 import com.listywave.user.application.dto.search.UserSearchResponse;
-import com.listywave.user.presentation.dto.ListVisibilityUpdateRequest;
 import io.restassured.common.mapper.TypeRef;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -231,70 +227,6 @@ public class UserAcceptanceTest extends AcceptanceTest {
 
             // when
             var 응답 = 프로필_수정_요청(정수_액세스_토큰, 동호.getId(), 프로필_수정_요청_데이터);
-
-            // then
-            HTTP_상태_코드를_검증한다(응답, FORBIDDEN);
-        }
-    }
-
-    @Nested
-    class 피드에서_내_리스트_공개_여부_설정 {
-
-        @Test
-        void 내_피드의_공개_리스트_비공개로_설정() {
-            // given
-            var 정수 = 회원을_저장한다(정수());
-            var 정수_액세스_토큰 = 액세스_토큰을_발급한다(정수);
-            var 정수_리스트_ID = 리스트_저장_API_호출(가장_좋아하는_견종_TOP3_생성_요청_데이터(List.of()), 정수_액세스_토큰)
-                    .as(ListCreateResponse.class)
-                    .listId();
-            var 내_피드_비공개_설정_데이터 = 내_피드_공개_여부_설정_데이터(정수_리스트_ID, false);
-
-            // when
-            var 응답 = 내_피드_리스트_공개_여부_설정_API_호출(정수_액세스_토큰, 내_피드_비공개_설정_데이터);
-            var 수정_이후_리스트_공개_여부_조회_결과 = 회원용_리스트_상세_조회_API_호출(정수_액세스_토큰, 정수_리스트_ID);
-
-            // then
-            HTTP_상태_코드를_검증한다(응답, OK);
-            assertThat(수정_이후_리스트_공개_여부_조회_결과.isPublic()).isFalse();
-        }
-
-        @Test
-        void 내_피드의_비공개_리스트_공개로_설정() {
-            // given
-            var 정수 = 회원을_저장한다(정수());
-            var 정수_액세스_토큰 = 액세스_토큰을_발급한다(정수);
-            var 정수_리스트_ID = 리스트_저장_API_호출(가장_좋아하는_견종_TOP3_생성_요청_데이터(List.of()), 정수_액세스_토큰)
-                    .as(ListCreateResponse.class)
-                    .listId();
-            var 내_피드_비공개_설정_데이터 = 내_피드_공개_여부_설정_데이터(정수_리스트_ID, false);
-            내_피드_리스트_공개_여부_설정_API_호출(정수_액세스_토큰, 내_피드_비공개_설정_데이터);
-
-            var 내_피드_공개_설정_데이터 = 내_피드_공개_여부_설정_데이터(정수_리스트_ID, true);
-
-            // when
-            var 응답 = 내_피드_리스트_공개_여부_설정_API_호출(정수_액세스_토큰, 내_피드_공개_설정_데이터);
-            var 수정_이후_리스트_공개_여부_조회_결과 = 회원용_리스트_상세_조회_API_호출(정수_액세스_토큰, 정수_리스트_ID);
-
-            // then
-            HTTP_상태_코드를_검증한다(응답, OK);
-            assertThat(수정_이후_리스트_공개_여부_조회_결과.isPublic()).isTrue();
-        }
-
-        @Test
-        void 내_피드가_아닌_리스트는_공개_여부_설정을_할_수_없다() {
-            // given
-            var 정수 = 회원을_저장한다(정수());
-            var 동호 = 회원을_저장한다(동호());
-            var 정수_액세스_토큰 = 액세스_토큰을_발급한다(정수);
-            var 동호_액세스_토큰 = 액세스_토큰을_발급한다(동호);
-            var 동호_리스트_ID = 리스트_저장_API_호출(가장_좋아하는_견종_TOP3_생성_요청_데이터(List.of()), 동호_액세스_토큰)
-                    .as(ListCreateResponse.class)
-                    .listId();
-            var 내_피드_비공개_설정_데이터 = 내_피드_공개_여부_설정_데이터(동호_리스트_ID, false);
-
-            // when
-            var 응답 = 내_피드_리스트_공개_여부_설정_API_호출(정수_액세스_토큰, 내_피드_비공개_설정_데이터);
 
             // then
             HTTP_상태_코드를_검증한다(응답, FORBIDDEN);

--- a/src/test/java/com/listywave/acceptance/user/UserAcceptanceTestHelper.java
+++ b/src/test/java/com/listywave/acceptance/user/UserAcceptanceTestHelper.java
@@ -87,23 +87,4 @@ public abstract class UserAcceptanceTestHelper {
                 .then().log().all()
                 .extract();
     }
-
-    public static ExtractableResponse<Response> 내_피드_리스트_공개_여부_설정_API_호출(
-            String accessToken,
-            ListVisibilityUpdateRequest request
-    ) {
-        return given()
-                .header(AUTHORIZATION, "Bearer " + accessToken)
-                .body(request)
-                .when().patch("/users/list-visibility")
-                .then().log().all()
-                .extract();
-    }
-
-    public static ListVisibilityUpdateRequest 내_피드_공개_여부_설정_데이터(Long listId, boolean isPublic) {
-        return new ListVisibilityUpdateRequest(
-                listId,
-                isPublic
-        );
-    }
 }

--- a/src/test/java/com/listywave/acceptance/user/UserAcceptanceTestHelper.java
+++ b/src/test/java/com/listywave/acceptance/user/UserAcceptanceTestHelper.java
@@ -3,6 +3,7 @@ package com.listywave.acceptance.user;
 import static com.listywave.acceptance.common.CommonAcceptanceHelper.given;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
+import com.listywave.user.presentation.dto.ListVisibilityUpdateRequest;
 import com.listywave.user.presentation.dto.UserProfileUpdateRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -85,5 +86,24 @@ public abstract class UserAcceptanceTestHelper {
                 .when().patch("/users/{userId}", userId)
                 .then().log().all()
                 .extract();
+    }
+
+    public static ExtractableResponse<Response> 내_피드_리스트_공개_여부_설정_API_호출(
+            String accessToken,
+            ListVisibilityUpdateRequest request
+    ) {
+        return given()
+                .header(AUTHORIZATION, "Bearer " + accessToken)
+                .body(request)
+                .when().patch("/users/list-visibility")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ListVisibilityUpdateRequest 내_피드_공개_여부_설정_데이터(Long listId, boolean isPublic) {
+        return new ListVisibilityUpdateRequest(
+                listId,
+                isPublic
+        );
     }
 }

--- a/src/test/java/com/listywave/list/application/domain/list/ListEntityTest.java
+++ b/src/test/java/com/listywave/list/application/domain/list/ListEntityTest.java
@@ -183,7 +183,7 @@ class ListEntityTest {
     void 공개_여부를_수정할_수_있다() {
         assertThat(list.isPublic()).isTrue();
 
-        list.updateVisibility(false);
+        list.updateVisibility();
 
         assertThat(list.isPublic()).isFalse();
     }


### PR DESCRIPTION
# Description

###  🛠️ 변경한 사항
ex) 1번 리스트가 공개인 경우
**ASIS**
- 공개 리스트를 비공개로 설정하려는 경우 기존에는 요청 body에 현재 상태(isPublic = true)를 보내서 API측에서 현재 상태에서 반대로(isPublic = false) 바꾸는 방식으로 진행함
그런데 이 방식은 프론트측에서 리스트 상세에서 받는 isPublic과 뭔가 매칭이 안되서 햇갈린다고 통일을 요청함

**TOBE**
- 해당 리스트가 공개일때 이를 비공개로 바꾸고자 할때 isPublic = false로 보냄( 내가 바꾸고 싶은 상태를 보내는 방식)

- 해당 부분에 테스트 코드가 존재하지 않아서 테스트 코드를 추가함!

# Relation Issues
- close #289 
