### PR TITLE
refactor: 기존 최신리스트API -> 최신리스트와 팔로잉리스트 API로 분리

### DIFF
--- a/src/main/java/com/listywave/common/auth/AuthorizationInterceptor.java
+++ b/src/main/java/com/listywave/common/auth/AuthorizationInterceptor.java
@@ -24,6 +24,7 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
             new UriAndMethod("/lists/upload-url", GET),
             new UriAndMethod("/lists/upload-complete", GET),
             new UriAndMethod("/lists/{listId}/histories", GET),
+            new UriAndMethod("/lists", GET),
             new UriAndMethod("/users/{userId}/lists", GET),
             new UriAndMethod("/users/{userId}/followers", GET),
             new UriAndMethod("/users/{userId}/followings", GET),

--- a/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
+++ b/src/main/java/com/listywave/list/application/domain/list/ListEntity.java
@@ -91,6 +91,9 @@ public class ListEntity {
     @Embedded
     private Items items;
 
+    @Column(nullable = false)
+    private int updateCount;
+
     @CreatedDate
     @Temporal(TIMESTAMP)
     @Column(updatable = false)
@@ -258,5 +261,9 @@ public class ListEntity {
             return;
         }
         throw new CustomException(INVALID_ACCESS);
+    }
+
+    public void increaseUpdateCount(){
+        this.updateCount++;
     }
 }

--- a/src/main/java/com/listywave/list/application/dto/response/ListRecentResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/ListRecentResponse.java
@@ -1,7 +1,6 @@
 package com.listywave.list.application.dto.response;
 
 import com.listywave.list.application.domain.item.Item;
-import com.listywave.list.application.domain.label.Label;
 import com.listywave.list.application.domain.list.ListEntity;
 import java.time.LocalDateTime;
 import java.util.Comparator;
@@ -25,15 +24,13 @@ public record ListRecentResponse(
     @Builder
     public record ListResponse(
             Long id,
-            String category,
-            String backgroundColor,
             Long ownerId,
             String ownerNickname,
             String ownerProfileImage,
-            List<LabelsResponse> labels,
             String title,
             String description,
-            List<ItemsResponse> items
+            List<ItemsResponse> items,
+            int updateCount
     ) {
 
         public static List<ListResponse> toList(List<ListEntity> lists) {
@@ -45,35 +42,13 @@ public record ListRecentResponse(
         public static ListResponse of(ListEntity list) {
             return ListResponse.builder()
                     .id(list.getId())
-                    .category(list.getCategory().getViewName())
-                    .backgroundColor(list.getBackgroundColor().name())
                     .ownerId(list.getUser().getId())
                     .ownerNickname(list.getUser().getNickname())
                     .ownerProfileImage(list.getUser().getProfileImageUrl())
-                    .labels(LabelsResponse.toList(list.getLabels().getValues()))
                     .title(list.getTitle().getValue())
                     .description(list.getDescription().getValue())
                     .items(ItemsResponse.toList(list.getTop3Items().getValues()))
-                    .build();
-        }
-    }
-
-    @Builder
-    public record LabelsResponse(
-            Long id,
-            String name
-    ) {
-
-        public static List<LabelsResponse> toList(List<Label> labels) {
-            return labels.stream()
-                    .map(LabelsResponse::of)
-                    .toList();
-        }
-
-        public static LabelsResponse of(Label label) {
-            return LabelsResponse.builder()
-                    .id(label.getId())
-                    .name(label.getName())
+                    .updateCount(list.getUpdateCount())
                     .build();
         }
     }
@@ -82,15 +57,12 @@ public record ListRecentResponse(
     public record ItemsResponse(
             Long id,
             int rank,
-            String title,
-            String imageUrl
+            String title
     ) {
 
         public static List<ItemsResponse> toList(List<Item> items) {
             return items.stream()
-                    .sorted(Comparator.comparing(Item::getRanking))
                     .map(ItemsResponse::of)
-                    .limit(3)
                     .toList();
         }
 
@@ -99,7 +71,6 @@ public record ListRecentResponse(
                     .id(item.getId())
                     .rank(item.getRanking())
                     .title(item.getTitle().getValue())
-                    .imageUrl(item.getImageUrl().getValue())
                     .build();
         }
     }

--- a/src/main/java/com/listywave/list/application/service/ListService.java
+++ b/src/main/java/com/listywave/list/application/service/ListService.java
@@ -172,7 +172,7 @@ public class ListService {
     @Transactional(readOnly = true)
     public ListRecentResponse getRecentLists(LocalDateTime cursorUpdatedDate, CategoryType category, Pageable pageable) {
         Slice<ListEntity> result = listRepository.getRecentLists(cursorUpdatedDate, category, pageable);
-        return getListRecentResponse(result);
+        return toListRecentResponse(result);
     }
 
     @Transactional(readOnly = true)
@@ -187,10 +187,10 @@ public class ListService {
 
         Slice<ListEntity> result =
                 listRepository.getRecentListsByFollowing(myFollowingUsers, cursorUpdatedDate, pageable);
-        return getListRecentResponse(result);
+        return toListRecentResponse(result);
     }
 
-    private ListRecentResponse getListRecentResponse(Slice<ListEntity> result) {
+    private ListRecentResponse toListRecentResponse(Slice<ListEntity> result) {
         List<ListEntity> recentList = result.getContent();
 
         LocalDateTime cursorUpdatedDate = null;

--- a/src/main/java/com/listywave/list/presentation/controller/ListController.java
+++ b/src/main/java/com/listywave/list/presentation/controller/ListController.java
@@ -71,11 +71,21 @@ public class ListController {
 
     @GetMapping("/lists")
     ResponseEntity<ListRecentResponse> getRecentLists(
-            @OptionalAuth Long loginUserId,
+            @RequestParam(name = "cursorUpdatedDate", required = false) LocalDateTime cursorUpdatedDate,
+            @RequestParam(name = "category", defaultValue = "entire") CategoryType category,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        ListRecentResponse recentLists = listService.getRecentLists(cursorUpdatedDate, category, pageable);
+        return ResponseEntity.ok(recentLists);
+    }
+
+    @GetMapping("/lists/following")
+    ResponseEntity<ListRecentResponse> getRecentListsByFollowing(
+            @Auth Long loginUserId,
             @RequestParam(name = "cursorUpdatedDate", required = false) LocalDateTime cursorUpdatedDate,
             @PageableDefault(size = 10) Pageable pageable
     ) {
-        ListRecentResponse recentLists = listService.getRecentLists(loginUserId, cursorUpdatedDate, pageable);
+        ListRecentResponse recentLists = listService.getRecentListsByFollowing(loginUserId, cursorUpdatedDate, pageable);
         return ResponseEntity.ok(recentLists);
     }
 

--- a/src/main/java/com/listywave/list/repository/list/custom/CustomListRepository.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/CustomListRepository.java
@@ -13,7 +13,7 @@ public interface CustomListRepository {
 
     List<ListTrandingResponse> fetchTrandingLists();
 
-    Slice<ListEntity> getRecentLists(LocalDateTime cursorUpdatedDate, Pageable pageable);
+    Slice<ListEntity> getRecentLists(LocalDateTime cursorUpdatedDate, CategoryType category, Pageable pageable);
 
     Slice<ListEntity> getRecentListsByFollowing(List<User> followingUsers, LocalDateTime cursorUpdatedDate, Pageable pageable);
 

--- a/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
+++ b/src/main/java/com/listywave/list/repository/list/custom/impl/CustomListRepositoryImpl.java
@@ -98,17 +98,17 @@ public class CustomListRepositoryImpl implements CustomListRepository {
     }
 
     @Override
-    public Slice<ListEntity> getRecentLists(LocalDateTime cursorUpdatedDate, Pageable pageable) {
+    public Slice<ListEntity> getRecentLists(LocalDateTime cursorUpdatedDate, CategoryType category, Pageable pageable) {
         LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
 
         List<ListEntity> fetch = queryFactory
                 .selectFrom(listEntity)
                 .join(listEntity.user, user).fetchJoin()
-                .leftJoin(label).on(listEntity.id.eq(label.list.id))
                 .leftJoin(item).on(listEntity.id.eq(item.list.id))
                 .where(
                         listEntity.updatedDate.goe(thirtyDaysAgo),
                         updatedDateLt(cursorUpdatedDate),
+                        categoryEq(category),
                         listEntity.user.isDelete.eq(false),
                         listEntity.isPublic.eq(true)
                 )
@@ -142,7 +142,6 @@ public class CustomListRepositoryImpl implements CustomListRepository {
         List<ListEntity> fetch = queryFactory
                 .selectFrom(listEntity)
                 .join(listEntity.user, user).fetchJoin()
-                .leftJoin(label).on(listEntity.id.eq(label.list.id))
                 .leftJoin(item).on(listEntity.id.eq(item.list.id))
                 .where(
                         listEntity.updatedDate.goe(thirtyDaysAgo),

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -5,32 +5,7 @@ import static com.listywave.acceptance.comment.CommentAcceptanceTestHelper.n개�
 import static com.listywave.acceptance.comment.CommentAcceptanceTestHelper.댓글_저장_API_호출;
 import static com.listywave.acceptance.common.CommonAcceptanceHelper.HTTP_상태_코드를_검증한다;
 import static com.listywave.acceptance.follow.FollowAcceptanceTestHelper.팔로우_요청_API;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.가장_좋아하는_견종_TOP3_생성_요청_데이터;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.검색_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.리스트_삭제_요청_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.리스트_상세_조회를_검증한다;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.리스트_수정_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.리스트_저장_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.리스트의_아이템_순위와_히스토리의_아이템_순위를_검증한다;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원_리스트_상세_조회_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원_최신_리스트_10개_조회_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원_피드_리스트_조회_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원_히스토리_조회_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원이_피드_리스트_조회_카테고리_콜라보레이터_필터링_요청;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원이_피드_리스트_조회_카테고리_필터링_요청;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.비회원이_피드_리스트_조회_콜라보레이터_필터링_요청;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.아이템_순위와_라벨을_바꾼_좋아하는_견종_TOP3_요청_데이터;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.정렬기준을_포함한_검색_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.좋아하는_라면_TOP3_생성_요청_데이터;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.카테고리로_검색_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.카테고리와_키워드로_검색_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.콜렉트_요청_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.키워드로_검색_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.키워드와_정렬기준을_포함한_검색_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.트랜딩_리스트_조회_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.회원_최신_리스트_10개_조회_API_호출;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.회원_피드_리스트_조회;
-import static com.listywave.acceptance.list.ListAcceptanceTestHelper.회원용_리스트_상세_조회_API_호출;
+import static com.listywave.acceptance.list.ListAcceptanceTestHelper.*;
 import static com.listywave.acceptance.reply.ReplyAcceptanceTestHelper.답글_등록_API_호출;
 import static com.listywave.list.fixture.ListFixture.가장_좋아하는_견종_TOP3;
 import static com.listywave.list.fixture.ListFixture.가장_좋아하는_견종_TOP3_순위_변경;
@@ -287,7 +262,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        void 아이템_순위에_변동이_있으면_히스토리로_기록되고_lastUpdatedDate가_갱신된다() {
+        void 아이템_순위에_변동이_있으면_히스토리로_기록되고_lastUpdatedDate가_갱신되고_updateCount가_증가한다() {
             // given
             var 동호 = 회원을_저장한다(동호());
             var 동호_액세스_토큰 = 액세스_토큰을_발급한다(동호);
@@ -343,7 +318,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        void 아이템의_순위_변동이_일어나지_않으면_updatedDate가_갱신되지_않는다() {
+        void 아이템의_순위_변동이_일어나지_않으면_updatedDate와_updateCount가_갱신되지_않는다() {
             // given
             var 동호 = 회원을_저장한다(동호());
             var 정수 = 회원을_저장한다(정수());
@@ -564,7 +539,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
     }
 
     @Nested
-    class 리스트_탐색 {
+    class 리스트_홈 {
 
         @Test
         void 트랜딩_리스트를_조회한다() {
@@ -619,7 +594,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        void 회원이_최신_리스트_10개를_조회하면_팔로우한_사용자의_최신_리스트_10개가_반환된다() {
+        void 팔로우한_사용자의_최신_리스트_10개를_조회한다() {
             // given
             var 동호 = 회원을_저장한다(동호());
             var 정수 = 회원을_저장한다(정수());
@@ -630,7 +605,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
             리스트를_모두_저장한다(지정된_개수만큼_리스트를_생성한다(동호, 5));
 
             // when
-            var response = 회원_최신_리스트_10개_조회_API_호출(동호_액세스_토큰);
+            var response = 팔로우한_사용자의_최신_리스트_10개_조회_API_호출(동호_액세스_토큰);
             var result = response.as(ListRecentResponse.class);
 
             // then
@@ -638,7 +613,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        void 비회원이_최신_리스트_10개를_조회한다() {
+        void 최신_리스트_10개를_조회한다() {
             // given
             var 동호 = 회원을_저장한다(동호());
             var 정수 = 회원을_저장한다(정수());
@@ -649,10 +624,11 @@ public class ListAcceptanceTest extends AcceptanceTest {
             리스트를_모두_저장한다(지정된_개수만큼_리스트를_생성한다(동호, 5));
 
             // when
-            var 결과 = 비회원_최신_리스트_10개_조회_API_호출().as(ListRecentResponse.class);
+            var 결과 = 최신_리스트_10개_조회_카테고리_필터링_API_호출(CategoryType.ENTIRE.name().toLowerCase())
+                    .as(ListRecentResponse.class);
 
             // then
-            var 동호_리스트 = 비회원_피드_리스트_조회_API_호출(동호).as(FindFeedListResponse.class).feedLists();
+            var 동호_리스트 = 비회원_피드_리스트_조회_API_호출(동호 ).as(FindFeedListResponse.class).feedLists();
             var 정수_리스트 = 비회원_피드_리스트_조회_API_호출(정수).as(FindFeedListResponse.class).feedLists();
             var 모든_리스트 = new ArrayList<>(동호_리스트);
             모든_리스트.addAll(정수_리스트);

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTest.java
@@ -539,7 +539,7 @@ public class ListAcceptanceTest extends AcceptanceTest {
     }
 
     @Nested
-    class 리스트_홈 {
+    class 리스트_팀섹 {
 
         @Test
         void 트랜딩_리스트를_조회한다() {

--- a/src/test/java/com/listywave/acceptance/list/ListAcceptanceTestHelper.java
+++ b/src/test/java/com/listywave/acceptance/list/ListAcceptanceTestHelper.java
@@ -184,17 +184,17 @@ public abstract class ListAcceptanceTestHelper {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 비회원_최신_리스트_10개_조회_API_호출() {
+    public static ExtractableResponse<Response> 최신_리스트_10개_조회_카테고리_필터링_API_호출(String category) {
         return given()
-                .when().get("/lists")
+                .when().get("/lists?category={category}", category)
                 .then().log().all()
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 회원_최신_리스트_10개_조회_API_호출(String accessToken) {
+    public static ExtractableResponse<Response> 팔로우한_사용자의_최신_리스트_10개_조회_API_호출(String accessToken) {
         return given()
                 .header(AUTHORIZATION, "Bearer " + accessToken)
-                .when().get("/lists")
+                .when().get("/lists/following")
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/com/listywave/list/fixture/ListFixture.java
+++ b/src/test/java/com/listywave/list/fixture/ListFixture.java
@@ -156,6 +156,13 @@ public abstract class ListFixture {
                                         new ItemComment(String.valueOf(i + 2)),
                                         new ItemLink(String.valueOf(i + 2)),
                                         new ItemImageUrl(String.valueOf(i + 2))
+                                ),
+                                Item.init(
+                                        i + 3,
+                                        new ItemTitle(String.valueOf(i + 3)),
+                                        new ItemComment(String.valueOf(i + 3)),
+                                        new ItemLink(String.valueOf(i + 3)),
+                                        new ItemImageUrl(String.valueOf(i + 3))
                                 )
                         ))
                 )).toList();


### PR DESCRIPTION
# Description


### 🛠️변경사항

탐색 -> 홈으로 변경되었고, 최신리스트와 팔로잉리스트로 페이지가 분리 되었으며 
- 최신리스트에는 로그인 유무 없이 무조건 모든 사용자의 최근 30일동안 수정된 순의 리스트를 가져오는 방식으로 변경
- 팔로잉 최신리스트는 로그인을 필수로 해야하며 내가 팔로잉한 사용자들의 최근 30일동안 수정된 순의 리스트를 가져옴

추가적으로 최신리스트 API queryParam에 category가 추가됨
최신리스트 : GET "/lists?size={}&cursorUpdatedDate={}&category={}"
팔로잉리스트 : GET "/lists/following?size={}&cursorUpdatedDate={}"

### 기타 추가사항
List에 updateCount 추가 (업데이트 N회째)
리스트 수정시 updateCount + 1 되도록 수정

### 특이사항
리스트 수정 테스트에 updateCount 증가 명칭만 추가 하였고, 추후 리스트 상세 API 변경때 내부적으로 해당 로직 추가 예정 

### 🚨 Merge하기 전 주의!
- List 테이블에 updateCount 필드가 추가 되어서 `dev`와 `prod`에 merge 하기 전 꼭 필수로 해당 테이블에 updateCount 추가하고 merge하기   현재 배포와 개발 서버에 ddl-auto = validate 이기 때문에 직접 수정해줘야함 )
```
alter table list
    add update_count int not null;
```

# Relation Issues
- close #291 
