### PR TITLE
infra: gradle-cache-action 버전 업그레이드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'corretto'
 
       - name: Gradle 셋업, 빌드, 캐시
-        uses: burrunan/gradle-cache-action@3bf23b8dd95e7d2bacf2470132454fe893a178a1
+        uses: burrunan/gradle-cache-action@c15634bb25b7284dc084f38dff4e838048b7feaf
         with:
           arguments: build
           properties: |


### PR DESCRIPTION
# Description
## 문제
최대 1\~2분 걸리던 CI 워크플로우가 최소 3분에서 최대 5\~6분이 걸렸다.

## 해결
Gradle 셋업, 빌드, 캐싱을 위해 사용하는 [gradle-cache-action 라이브러리](https://github.com/burrunan/gradle-cache-action)의 버전 업그레이드

## 원인
GitHub Actions가 강제로 Node.js 버전을 16에서 20으로 업그레이드하면서 HTTP Timeout default 값이 5초에서 60초로 변경됨에 따라 딜레이가 발생한 것으로 예상된다.

기존에 사용하던 v1은 node16을 사용하고 있었다.
따라서 node20을 사용하는 v2로 업그레이드하였고, 실제로 [해당 이슈에 대응](https://github.com/burrunan/gradle-cache-action/pull/74/files#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2ece)한 것으로 파악했다.

실제로 Actions 라이브러리 중, setup-java의 경우에도 [이와 비슷한 문제](https://github.com/actions/setup-java/issues/591)가 발생한 적이 있다.

# Relation Issues
- close #310 
