### PR TITLE
feat: 댓글/답글에서 멘션 당한 유저가 탈퇴한 경우 보여지는 값 수정 (#313)

### DIFF
--- a/src/main/java/com/listywave/list/application/dto/response/CommentFindResponse.java
+++ b/src/main/java/com/listywave/list/application/dto/response/CommentFindResponse.java
@@ -6,6 +6,7 @@ import static java.util.Comparator.comparingLong;
 import com.listywave.list.application.domain.comment.Comment;
 import com.listywave.list.application.domain.reply.Reply;
 import com.listywave.mention.Mention;
+import com.listywave.user.application.domain.User;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -119,10 +120,14 @@ public record CommentFindResponse(
 
         public static List<MentionDto> toList(List<Mention> mentions) {
             return mentions.stream()
-                    .map(Mention::getUser)
-                    .filter(user -> !user.isDelete())
-                    .map(user -> new MentionDto(user.getId(), user.getNickname()))
-                    .sorted(comparingLong(MentionDto::userId))
+                    .sorted(comparingLong(Mention::getId))
+                    .map(mention -> {
+                        User user = mention.getUser();
+                        if (user.isDelete()) {
+                            return new MentionDto(0L, "withdrawer");
+                        }
+                        return new MentionDto(user.getId(), user.getNickname());
+                    })
                     .toList();
         }
     }

--- a/src/test/java/com/listywave/mention/MentionServiceTest.java
+++ b/src/test/java/com/listywave/mention/MentionServiceTest.java
@@ -122,10 +122,9 @@ public class MentionServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 댓글에서_멘션을_당한_사용자가_탈퇴한_사용자인_경우_조회하지_않는다() {
+        void 댓글에서_멘션을_당한_사용자가_탈퇴한_사용자인_경우_id는_0이고_닉네임은_withdrawer로_응답한다() {
             // given
-            List<Long> mentionIds = List.of(js.getId(), ej.getId());
-            commentService.create(list.getId(), dh.getId(), "댓글이용", mentionIds);
+            commentService.create(list.getId(), dh.getId(), "댓글이용", List.of(js.getId(), ej.getId()));
 
             // when
             authService.withdraw(js.getId());
@@ -133,9 +132,21 @@ public class MentionServiceTest extends IntegrationTest {
             // then
             CommentFindResponse response = commentService.findAllBy(list.getId(), 5, null);
             CommentDto commentDto = response.comments().get(0);
+            List<MentionDto> mentions = commentDto.mentions();
 
-            assertThat(commentDto.mentions()).hasSize(1);
-            assertThat(commentDto.mentions().get(0).userId()).isEqualTo(ej.getId());
+            assertAll(
+                    () -> assertThat(mentions).hasSize(2),
+                    () -> {
+                        MentionDto mentionToJs = mentions.get(0);
+                        assertThat(mentionToJs.userId()).isEqualTo(0L);
+                        assertThat(mentionToJs.userNickname()).isEqualTo("withdrawer");
+                    },
+                    () -> {
+                        MentionDto mentionToEj = mentions.get(1);
+                        assertThat(mentionToEj.userId()).isEqualTo(ej.getId());
+                        assertThat(mentionToEj.userNickname()).isEqualTo(ej.getNickname());
+                    }
+            );
         }
 
         @Test
@@ -169,11 +180,10 @@ public class MentionServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 답글에서_멘션을_당한_사용자가_탈퇴한_사용자인_경우_조회하지_않는다() {
+        void 답글에서_멘션을_당한_사용자가_탈퇴한_사용자인_경우_id는_0이고_닉네임은_withdrawer으로_응답한다() {
             // given
             Long commentId = commentService.create(list.getId(), dh.getId(), "댓글이용", EMPTY_LIST).id();
-            List<Long> mentionIds = List.of(dh.getId(), ej.getId());
-            replyService.create(list.getId(), commentId, js.getId(), "답글이용", mentionIds);
+            replyService.create(list.getId(), commentId, js.getId(), "답글이용", List.of(dh.getId(), ej.getId()));
 
             authService.withdraw(ej.getId());
 
@@ -183,8 +193,13 @@ public class MentionServiceTest extends IntegrationTest {
 
             // then
             assertAll(
-                    () -> assertThat(reply.mentions()).hasSize(1),
-                    () -> assertThat(reply.mentions().get(0).userId()).isEqualTo(dh.getId())
+                    () -> assertThat(reply.mentions()).hasSize(2),
+                    () -> assertThat(reply.mentions().get(0).userId()).isEqualTo(dh.getId()),
+                    () -> {
+                        MentionDto mentionToEj = reply.mentions().get(1);
+                        assertThat(mentionToEj.userId()).isEqualTo(0L);
+                        assertThat(mentionToEj.userNickname()).isEqualTo("withdrawer");
+                    }
             );
         }
     }


### PR DESCRIPTION
# Description
댓글/답글에서 멘션 당한 유저가 탈퇴한 경우, _withdrawer_ 로 응답하도록 하는 요구 사항에 대응했습니다.

# Relation Issues
- close #313 
