### PR TITLE
feat: 탈퇴 처리를 30일 이전의 유저를 삭제하는 기능 구현

### DIFF
--- a/src/main/java/com/listywave/user/application/domain/User.java
+++ b/src/main/java/com/listywave/user/application/domain/User.java
@@ -133,19 +133,19 @@ public class User extends BaseEntity {
         }
     }
 
-    public void follow(User followingUser) {
+    public void follow(User 내가_팔로우_할_유저) {
         this.increaseFollowingCount();
-        followingUser.increaseFollowerCount();
+        내가_팔로우_할_유저.increaseFollowerCount();
     }
 
-    public void unfollow(User followingUser) {
+    public void unfollow(User 내가_팔로우_하고_있는_유저) {
         this.decreaseFollowingCount();
-        followingUser.decreaseFollowerCount();
+        내가_팔로우_하고_있는_유저.decreaseFollowerCount();
     }
 
-    public void remove(User followerUser) {
+    public void removeFollower(User 나를_팔로우_하고_있는_유저) {
         this.decreaseFollowerCount();
-        followerUser.decreaseFollowingCount();
+        나를_팔로우_하고_있는_유저.decreaseFollowingCount();
     }
 
     private void increaseFollowingCount() {

--- a/src/main/java/com/listywave/user/application/domain/User.java
+++ b/src/main/java/com/listywave/user/application/domain/User.java
@@ -3,6 +3,7 @@ package com.listywave.user.application.domain;
 import static com.listywave.common.exception.ErrorCode.ALREADY_LOGOUT_EXCEPTION;
 import static com.listywave.common.exception.ErrorCode.EXCEED_FOLLOW_COUNT_EXCEPTION;
 import static com.listywave.common.exception.ErrorCode.INVALID_ACCESS;
+import static jakarta.persistence.TemporalType.TIMESTAMP;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.listywave.common.BaseEntity;
@@ -17,6 +18,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -66,6 +69,10 @@ public class User extends BaseEntity {
     @Column(nullable = false, length = 5)
     private boolean isDelete;
 
+    @Temporal(TIMESTAMP)
+    @Column(nullable = true)
+    private LocalDateTime deleteAt;
+
     public static User init(Long oauthId, String oauthEmail, String kakaoAccessToken) {
         return new User(
                 oauthId,
@@ -78,7 +85,8 @@ public class User extends BaseEntity {
                 0,
                 false,
                 kakaoAccessToken,
-                false
+                false,
+                null
         );
     }
 
@@ -165,6 +173,7 @@ public class User extends BaseEntity {
 
     public void softDelete() {
         this.isDelete = true;
+        this.deleteAt = LocalDateTime.now();
     }
 
     public void updateKakaoAccessToken(String kakaoAccessToken) {

--- a/src/main/java/com/listywave/user/application/service/UserDeleteBatchService.java
+++ b/src/main/java/com/listywave/user/application/service/UserDeleteBatchService.java
@@ -1,0 +1,26 @@
+package com.listywave.user.application.service;
+
+import com.listywave.user.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserDeleteBatchService {
+
+    private final UserRepository userRepository;
+
+    @Async
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *")
+    public void deleteUsers30DaysAgo() {
+        log.info("\n ============== UserDeleteScheduler Start ================ \n");
+        userRepository.deleteNDaysAgo(30);
+        log.info("\n ============== UserDeleteScheduler End ================ \n");
+    }
+}

--- a/src/main/java/com/listywave/user/application/service/UserService.java
+++ b/src/main/java/com/listywave/user/application/service/UserService.java
@@ -170,13 +170,13 @@ public class UserService {
         return userRepository.existsByNicknameValueIgnoreCase(nickname);
     }
 
-    public void deleteFollower(Long followerUserId, Long followingUserId) {
-        User followerUser = userRepository.getById(followerUserId);
-        User followingUser = userRepository.getById(followingUserId);
+    public void deleteFollower(Long 팔로우_하는_유저_ID, Long 팔로우_당하는_유저_ID) {
+        User 팔로우_하는_유저 = userRepository.getById(팔로우_하는_유저_ID);
+        User 팔로우_당하는_유저 = userRepository.getById(팔로우_당하는_유저_ID);
 
-        followRepository.deleteByFollowingUserAndFollowerUser(followingUser, followerUser);
+        followRepository.deleteByFollowingUserAndFollowerUser(팔로우_당하는_유저, 팔로우_하는_유저);
 
-        followingUser.remove(followerUser);
+        팔로우_당하는_유저.removeFollower(팔로우_하는_유저);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/listywave/user/repository/user/custom/CustomUserRepository.java
+++ b/src/main/java/com/listywave/user/repository/user/custom/CustomUserRepository.java
@@ -13,4 +13,6 @@ public interface CustomUserRepository {
     Long countBySearch(String search, Long loginUserId);
 
     Slice<UserSearchResult> findAllBySearch(String search, Pageable pageable, Long loginUserId);
+
+    void deleteNDaysAgo(int n);
 }

--- a/src/main/java/com/listywave/user/repository/user/custom/impl/CustomUserRepositoryImpl.java
+++ b/src/main/java/com/listywave/user/repository/user/custom/impl/CustomUserRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -96,5 +97,14 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
                 .offset(pageable.getOffset())
                 .fetch();
         return checkEndPage(pageable, fetch);
+    }
+
+    @Override
+    public void deleteNDaysAgo(int n) {
+        LocalDateTime nDaysAgo = LocalDateTime.now().minusDays(n);
+
+        queryFactory.delete(user)
+                .where(user.isDelete.isTrue().and(user.deleteAt.loe(nDaysAgo)))
+                .execute();
     }
 }

--- a/src/test/java/com/listywave/user/application/domain/UserTest.java
+++ b/src/test/java/com/listywave/user/application/domain/UserTest.java
@@ -237,7 +237,7 @@ class UserTest {
             user.follow(other);
 
             // when
-            other.remove(user);
+            other.removeFollower(user);
 
             // then
             assertThat(user.getFollowingCount()).isZero();
@@ -300,10 +300,17 @@ class UserTest {
     }
 
     @Test
-    void 삭제_처리를_할_수_있다() {
+    void 회원_탈퇴_시_softDelete_방식으로_삭제_처리를_한다() {
+        // given
+        assertThat(user.isDelete()).isFalse();
+        assertThat(user.getDeleteAt()).isNull();
+
+        // when
         user.softDelete();
 
+        // then
         assertThat(user.isDelete()).isTrue();
+        assertThat(user.getDeleteAt()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
# Description
1. 탈퇴 처리한 30일 이전의 유저를 삭제하는 기능을 구현했습니다.
2. 팔로우 관련 로직에서 변수명이 영어로 되니까 너무 헷갈려서 한글로 변경했습니다.

# Relation Issues
- close #227 
