### PR TITLE
feat: 어드민 전용 API에 인증 로직 추가

### DIFF
--- a/src/main/java/com/listywave/notice/application/domain/Notice.java
+++ b/src/main/java/com/listywave/notice/application/domain/Notice.java
@@ -6,11 +6,14 @@ import static jakarta.persistence.FetchType.LAZY;
 import static java.util.Comparator.comparingInt;
 import static lombok.AccessLevel.PROTECTED;
 
+import com.listywave.admin.Admin;
 import com.listywave.common.BaseEntity;
 import com.listywave.common.exception.CustomException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
@@ -36,13 +39,23 @@ public class Notice extends BaseEntity {
 
     private boolean didSendAlarm;
 
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "create_admin_id")
+    private Admin createAdmin;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "update_admin_id")
+    private Admin lastUpdateAdmin;
+
     @OneToMany(mappedBy = "notice", fetch = LAZY, cascade = ALL, orphanRemoval = true)
     private final List<NoticeContent> contents = new ArrayList<>();
 
-    public Notice(NoticeType type, NoticeTitle title, NoticeDescription description) {
+    public Notice(NoticeType type, NoticeTitle title, NoticeDescription description, Admin createAdmin) {
         this.type = type;
         this.title = title;
         this.description = description;
+        this.createAdmin = createAdmin;
+        this.lastUpdateAdmin = createAdmin;
     }
 
     public void addContents(List<NoticeContent> contents) {
@@ -58,17 +71,25 @@ public class Notice extends BaseEntity {
         return result.orElse(null);
     }
 
-    public void update(NoticeType type, NoticeTitle title, NoticeDescription description, List<NoticeContent> contents) {
+    public void update(
+            NoticeType type,
+            NoticeTitle title,
+            NoticeDescription description,
+            List<NoticeContent> contents,
+            Admin updateAdmin
+    ) {
         this.type = type;
         this.title = title;
         this.description = description;
+        this.lastUpdateAdmin = updateAdmin;
 
         this.contents.clear();
         this.contents.addAll(contents);
     }
 
-    public void changeExposure() {
+    public void changeExposure(Admin updateAdmin) {
         this.isExposed = !this.isExposed;
+        this.lastUpdateAdmin = updateAdmin;
     }
 
     public void sendAlarm() {

--- a/src/main/java/com/listywave/notice/application/service/NoticeService.java
+++ b/src/main/java/com/listywave/notice/application/service/NoticeService.java
@@ -1,5 +1,7 @@
 package com.listywave.notice.application.service;
 
+import com.listywave.admin.Admin;
+import com.listywave.admin.AdminRepository;
 import com.listywave.alarm.application.domain.AlarmCreateEvent;
 import com.listywave.notice.application.domain.Notice;
 import com.listywave.notice.application.domain.NoticeContent;
@@ -30,16 +32,19 @@ public class NoticeService {
     private final UserRepository userRepository;
     private final NoticeRepository noticeRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final AdminRepository adminRepository;
 
-    public Long create(NoticeCreateRequest request) {
-        Notice notice = request.toNotice();
+    public Long create(Long adminId, NoticeCreateRequest request) {
+        Admin admin = adminRepository.getById(adminId);
+        Notice notice = request.toNotice(admin);
         List<NoticeContent> noticeContents = request.toNoticeContents(notice);
         notice.addContents(noticeContents);
         return noticeRepository.save(notice).getId();
     }
 
     @Transactional(readOnly = true)
-    public List<NoticeFindAllResponseToAdmin> findAllToAdmin() {
+    public List<NoticeFindAllResponseToAdmin> findAllToAdmin(Long adminId) {
+        adminRepository.getById(adminId);
         List<Notice> notices = noticeRepository.findAll();
         return NoticeFindAllResponseToAdmin.toList(notices);
     }
@@ -58,7 +63,8 @@ public class NoticeService {
         return NoticeFindResponse.of(result, prevNotice, nextNotice);
     }
 
-    public void update(NoticeUpdateRequest request, Long noticeId) {
+    public void update(Long adminId, NoticeUpdateRequest request, Long noticeId) {
+        Admin admin = adminRepository.getById(adminId);
         Notice notice = noticeRepository.findByIdWithFetch(noticeId);
         List<NoticeContent> newNoticeContents = request.toNoticeContents(notice);
 
@@ -66,22 +72,27 @@ public class NoticeService {
                 NoticeType.codeOf(request.categoryCode()),
                 new NoticeTitle(request.title()),
                 new NoticeDescription(request.description()),
-                newNoticeContents
+                newNoticeContents,
+                admin
         );
     }
 
-    public void updateExposure(Long id) {
-        Notice notice = noticeRepository.findByIdWithFetch(id);
-        notice.changeExposure();
+    public void updateExposure(Long adminId, Long noticeId) {
+        Admin admin = adminRepository.getById(adminId);
+        Notice notice = noticeRepository.findByIdWithFetch(noticeId);
+        notice.changeExposure(admin);
     }
 
-    public void delete(Long id) {
-        noticeRepository.deleteById(id);
+    public void delete(Long adminId, Long noticeID) {
+        adminRepository.getById(adminId);
+        noticeRepository.deleteById(noticeID);
     }
 
-    public void sendAlarm(Long id) {
+    public void sendAlarm(Long adminId, Long noticeId) {
+        adminRepository.getById(adminId);
+
         User officialUser = userRepository.findByNicknameValue(OFFICIAL_USER_NICKNAME);
-        Notice notice = noticeRepository.getById(id);
+        Notice notice = noticeRepository.getById(noticeId);
         notice.sendAlarm();
 
         AlarmCreateEvent event = AlarmCreateEvent.notice(officialUser, notice);

--- a/src/main/java/com/listywave/notice/application/service/dto/NoticeCreateRequest.java
+++ b/src/main/java/com/listywave/notice/application/service/dto/NoticeCreateRequest.java
@@ -1,5 +1,6 @@
 package com.listywave.notice.application.service.dto;
 
+import com.listywave.admin.Admin;
 import com.listywave.notice.application.domain.ContentType;
 import com.listywave.notice.application.domain.Notice;
 import com.listywave.notice.application.domain.NoticeContent;
@@ -26,8 +27,8 @@ public record NoticeCreateRequest(
     ) {
     }
 
-    public Notice toNotice() {
-        return new Notice(NoticeType.codeOf(categoryCode), new NoticeTitle(title), new NoticeDescription(description));
+    public Notice toNotice(Admin admin) {
+        return new Notice(NoticeType.codeOf(categoryCode), new NoticeTitle(title), new NoticeDescription(description), admin);
     }
 
     public List<NoticeContent> toNoticeContents(Notice notice) {

--- a/src/main/java/com/listywave/notice/presentation/NoticeController.java
+++ b/src/main/java/com/listywave/notice/presentation/NoticeController.java
@@ -1,5 +1,6 @@
 package com.listywave.notice.presentation;
 
+import com.listywave.common.auth.Auth;
 import com.listywave.notice.application.domain.NoticeType;
 import com.listywave.notice.application.service.NoticeService;
 import com.listywave.notice.application.service.dto.NoticeCreateRequest;
@@ -29,21 +30,21 @@ public class NoticeController {
     private final NoticeService noticeService;
 
     @GetMapping("/admin/notices/categories")
-    ResponseEntity<List<NoticeCategoryFindResponse>> findNoticeCategories() {
+    ResponseEntity<List<NoticeCategoryFindResponse>> findNoticeCategories(@Auth Long adminId) {
         List<NoticeCategoryFindResponse> result = NoticeCategoryFindResponse.toList(NoticeType.values());
         return ResponseEntity.ok(result);
     }
 
     @PostMapping("/admin/notices")
-    ResponseEntity<NoticeCreateResponse> create(@RequestBody NoticeCreateRequest request) {
-        Long id = noticeService.create(request);
+    ResponseEntity<NoticeCreateResponse> create(@Auth Long adminId, @RequestBody NoticeCreateRequest request) {
+        Long id = noticeService.create(adminId, request);
         NoticeCreateResponse response = new NoticeCreateResponse(id);
         return ResponseEntity.created(URI.create("/admin/notices/" + id)).body(response);
     }
 
     @GetMapping("/admin/notices")
-    ResponseEntity<List<NoticeFindAllResponseToAdmin>> findAllToAdmin() {
-        List<NoticeFindAllResponseToAdmin> result = noticeService.findAllToAdmin();
+    ResponseEntity<List<NoticeFindAllResponseToAdmin>> findAllToAdmin(@Auth Long adminId) {
+        List<NoticeFindAllResponseToAdmin> result = noticeService.findAllToAdmin(adminId);
         return ResponseEntity.ok(result);
     }
 
@@ -60,26 +61,26 @@ public class NoticeController {
     }
 
     @PutMapping("/admin/notices/{noticeId}")
-    ResponseEntity<Void> update(@RequestBody NoticeUpdateRequest request, @PathVariable Long noticeId) {
-        noticeService.update(request, noticeId);
+    ResponseEntity<Void> update(@Auth Long adminId, @RequestBody NoticeUpdateRequest request, @PathVariable Long noticeId) {
+        noticeService.update(adminId, request, noticeId);
         return ResponseEntity.noContent().build();
     }
 
     @PatchMapping("/admin/notices/{noticeId}")
-    ResponseEntity<Void> updateExposure(@PathVariable Long noticeId) {
-        noticeService.updateExposure(noticeId);
+    ResponseEntity<Void> updateExposure(@Auth Long adminId, @PathVariable Long noticeId) {
+        noticeService.updateExposure(adminId, noticeId);
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/admin/notices/{noticeId}")
-    ResponseEntity<Void> delete(@PathVariable Long noticeId) {
-        noticeService.delete(noticeId);
+    ResponseEntity<Void> delete(@Auth Long adminId, @PathVariable Long noticeId) {
+        noticeService.delete(adminId, noticeId);
         return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/admin/notices/{noticeId}/alarm")
-    ResponseEntity<Void> sendAlarm(@PathVariable Long noticeId) {
-        noticeService.sendAlarm(noticeId);
+    ResponseEntity<Void> sendAlarm(@Auth Long adminId, @PathVariable Long noticeId) {
+        noticeService.sendAlarm(adminId, noticeId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/listywave/topic/application/service/TopicService.java
+++ b/src/main/java/com/listywave/topic/application/service/TopicService.java
@@ -1,5 +1,6 @@
 package com.listywave.topic.application.service;
 
+import com.listywave.admin.AdminRepository;
 import com.listywave.list.application.domain.category.CategoryType;
 import com.listywave.topic.application.domain.Topic;
 import com.listywave.topic.application.service.dto.ExposedTopicFindResponse;
@@ -23,6 +24,7 @@ public class TopicService {
 
     private final UserRepository userRepository;
     private final TopicRepository topicRepository;
+    private final AdminRepository adminRepository;
 
     public void create(TopicCreateRequest request, Long userId) {
         User user = userRepository.getById(userId);
@@ -37,7 +39,8 @@ public class TopicService {
     }
 
     @Transactional(readOnly = true)
-    public TopicFindResponse findAll(@Nullable Long cursorId, int size) {
+    public TopicFindResponse findAll(Long adminId, @Nullable Long cursorId, int size) {
+        adminRepository.getById(adminId);
         List<Topic> result = topicRepository.findAll(cursorId, size);
         long totalCount = (topicRepository.count() / size) + 1;
         return TopicFindResponse.from(result, size, totalCount);

--- a/src/main/java/com/listywave/topic/presentation/TopicController.java
+++ b/src/main/java/com/listywave/topic/presentation/TopicController.java
@@ -49,15 +49,16 @@ public class TopicController {
 
     @GetMapping("/admin/topics")
     ResponseEntity<TopicFindResponse> findAll(
+            @Auth Long adminId,
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "5") int size
     ) {
-        TopicFindResponse result = topicService.findAll(cursorId, size);
+        TopicFindResponse result = topicService.findAll(adminId, cursorId, size);
         return ResponseEntity.ok(result);
     }
 
     @PutMapping("/admin/topics/{topicId}")
-    ResponseEntity<Void> update(@PathVariable Long topicId, @RequestBody TopicUpdateRequest request) {
+    ResponseEntity<Void> update(@Auth Long adminId, @PathVariable Long topicId, @RequestBody TopicUpdateRequest request) {
         topicService.update(topicId, request.isExposed(), request.categoryCode(), request.title());
         return ResponseEntity.noContent().build();
     }

--- a/src/test/java/com/listywave/alarm/AlarmServiceTest.java
+++ b/src/test/java/com/listywave/alarm/AlarmServiceTest.java
@@ -25,7 +25,7 @@ import com.listywave.list.application.dto.ReplyDeleteCommand;
 import com.listywave.notice.application.domain.Notice;
 import com.listywave.notice.application.service.dto.NoticeCreateRequest;
 import java.util.List;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -269,7 +269,12 @@ public class AlarmServiceTest extends IntegrationTest {
         @Nested
         class 공지 {
 
-            private final Admin admin = adminRepository.save(new Admin(null, "1.2.3.4", "account", "1234"));
+            private Admin admin;
+
+            @BeforeEach
+            void setUp() {
+                this.admin = adminRepository.save(new Admin(null, "1.2.3.4", "account", "1234"));
+            }
 
             @Test
             void 공지_알람을_발송한다() {
@@ -446,12 +451,6 @@ public class AlarmServiceTest extends IntegrationTest {
 
     @Nested
     class 알람_삭제 {
-
-        @Test
-        @Disabled
-        void _30일이_지난_알람은_자동_삭제된다() {
-            // TODO: 테스트 작성
-        }
 
         @Test
         void 댓글이_삭제될_경우_관련_알람도_모두_삭제된다() {

--- a/src/test/java/com/listywave/alarm/AlarmServiceTest.java
+++ b/src/test/java/com/listywave/alarm/AlarmServiceTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.listywave.admin.Admin;
 import com.listywave.alarm.application.domain.AlarmCreateEvent;
 import com.listywave.alarm.application.dto.AlarmCheckResponse;
 import com.listywave.alarm.application.dto.AlarmFindResponse;
@@ -268,11 +269,13 @@ public class AlarmServiceTest extends IntegrationTest {
         @Nested
         class 공지 {
 
+            private final Admin admin = adminRepository.save(new Admin(null, "1.2.3.4", "account", "1234"));
+
             @Test
             void 공지_알람을_발송한다() {
                 // given
                 NoticeCreateRequest noticeCreateRequest = createNoticeCreateRequest();
-                Long noticeId = noticeService.create(noticeCreateRequest);
+                Long noticeId = noticeService.create(admin.getId(), noticeCreateRequest);
                 Notice notice = noticeRepository.getById(noticeId);
 
                 // when
@@ -301,11 +304,11 @@ public class AlarmServiceTest extends IntegrationTest {
             void 공지는_1개당_최대_1회만_알람을_보낼_수_있다() {
                 // given
                 NoticeCreateRequest noticeCreateRequest = createNoticeCreateRequest();
-                Long noticeId = noticeService.create(noticeCreateRequest);
-                noticeService.sendAlarm(noticeId);
+                Long noticeId = noticeService.create(admin.getId(), noticeCreateRequest);
+                noticeService.sendAlarm(admin.getId(), noticeId);
 
                 // when
-                ErrorCode result = assertThrows(CustomException.class, () -> noticeService.sendAlarm(noticeId))
+                ErrorCode result = assertThrows(CustomException.class, () -> noticeService.sendAlarm(admin.getId(), noticeId))
                         .getErrorCode();
 
                 // then

--- a/src/test/java/com/listywave/common/IntegrationTest.java
+++ b/src/test/java/com/listywave/common/IntegrationTest.java
@@ -107,7 +107,7 @@ public abstract class IntegrationTest {
     protected ListEntity list;
 
     @BeforeEach
-    void setUp() {
+    protected void setUp() {
         alarmRepository.deleteAllInBatch();
         noticeRepository.deleteAll();
         adminRepository.deleteAllInBatch();

--- a/src/test/java/com/listywave/notice/application/service/NoticeServiceTest.java
+++ b/src/test/java/com/listywave/notice/application/service/NoticeServiceTest.java
@@ -9,6 +9,7 @@ import static com.listywave.notice.application.domain.NoticeType.EVENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.listywave.admin.Admin;
 import com.listywave.common.IntegrationTest;
 import com.listywave.notice.application.domain.Notice;
 import com.listywave.notice.application.domain.NoticeType;
@@ -24,12 +25,14 @@ import org.junit.jupiter.api.Test;
 
 public class NoticeServiceTest extends IntegrationTest {
 
+    private final Admin admin = adminRepository.save(new Admin(null, "1.2.3.4", "account", "1234"));
+
     @Test
     void 공지를_생성_후_상세_조회한다() {
         // given
-        Long id1 = noticeService.create(createNoticeCreateRequest(1));
-        Long id2 = noticeService.create(createNoticeCreateRequest(2));
-        Long id3 = noticeService.create(createNoticeCreateRequest(3));
+        Long id1 = noticeService.create(admin.getId(), createNoticeCreateRequest(1));
+        Long id2 = noticeService.create(admin.getId(), createNoticeCreateRequest(2));
+        Long id3 = noticeService.create(admin.getId(), createNoticeCreateRequest(3));
 
         // when
         NoticeFindResponse result = noticeService.findOneSpecific(id2);
@@ -80,7 +83,7 @@ public class NoticeServiceTest extends IntegrationTest {
         NoticeCreateRequest request = createNoticeCreateRequest(1);
 
         // when
-        Long id = noticeService.create(request);
+        Long id = noticeService.create(admin.getId(), request);
 
         // then
         NoticeFindResponse result = noticeService.findOneSpecific(id);
@@ -97,7 +100,7 @@ public class NoticeServiceTest extends IntegrationTest {
         void 노출된_공지가_없을_때_전체_조회한다() {
             // given
             NoticeCreateRequest noticeCreateRequest = createNoticeCreateRequest(1);
-            noticeService.create(noticeCreateRequest);
+            noticeService.create(admin.getId(), noticeCreateRequest);
 
             // when
             List<NoticeFindAllResponseToUser> result = noticeService.findAllToUser();
@@ -109,12 +112,12 @@ public class NoticeServiceTest extends IntegrationTest {
         @Test
         void 노출_처리가_된_공지를_모두_조회한다() {
             // given
-            Long notice1Id = noticeService.create(createNoticeCreateRequest(1));
-            noticeService.create(createNoticeCreateRequest(2));
-            Long notice3Id = noticeService.create(createNoticeCreateRequest(3));
+            Long notice1Id = noticeService.create(admin.getId(), createNoticeCreateRequest(1));
+            noticeService.create(admin.getId(), createNoticeCreateRequest(2));
+            Long notice3Id = noticeService.create(admin.getId(), createNoticeCreateRequest(3));
 
-            noticeService.updateExposure(notice1Id);
-            noticeService.updateExposure(notice3Id);
+            noticeService.updateExposure(admin.getId(), notice1Id);
+            noticeService.updateExposure(admin.getId(), notice3Id);
 
             // when
             List<NoticeFindAllResponseToUser> result = noticeService.findAllToUser();
@@ -136,7 +139,7 @@ public class NoticeServiceTest extends IntegrationTest {
         void 공지를_수정한다() {
             // given
             NoticeCreateRequest createRequest = createNoticeCreateRequest(1);
-            Long noticeId = noticeService.create(createRequest);
+            Long noticeId = noticeService.create(admin.getId(), createRequest);
 
             // when
             NoticeUpdateRequest updateRequest = new NoticeUpdateRequest(
@@ -151,7 +154,7 @@ public class NoticeServiceTest extends IntegrationTest {
                             new NoticeUpdateRequest.ContentDto(1, "note", "유의사항입니다", null, null, null)
                     )
             );
-            noticeService.update(updateRequest, noticeId);
+            noticeService.update(admin.getId(), updateRequest, noticeId);
 
             // then
             NoticeFindResponse result = noticeService.findOneSpecific(noticeId);
@@ -169,10 +172,10 @@ public class NoticeServiceTest extends IntegrationTest {
         void 공지_노출_여부를_수정한다() {
             // given
             NoticeCreateRequest createRequest = createNoticeCreateRequest(1);
-            Long noticeId = noticeService.create(createRequest);
+            Long noticeId = noticeService.create(admin.getId(), createRequest);
 
             // when
-            noticeService.updateExposure(noticeId);
+            noticeService.updateExposure(admin.getId(), noticeId);
 
             // then
             Notice result = noticeRepository.getById(noticeId);
@@ -183,11 +186,11 @@ public class NoticeServiceTest extends IntegrationTest {
         void 노출이_된_공지를_미노출로_변경한다() {
             // given
             NoticeCreateRequest createRequest = createNoticeCreateRequest(1);
-            Long noticeId = noticeService.create(createRequest);
-            noticeService.updateExposure(noticeId);
+            Long noticeId = noticeService.create(admin.getId(), createRequest);
+            noticeService.updateExposure(admin.getId(), noticeId);
 
             // when
-            noticeService.updateExposure(noticeId);
+            noticeService.updateExposure(admin.getId(), noticeId);
 
             // then
             Notice result = noticeRepository.getById(noticeId);
@@ -199,10 +202,10 @@ public class NoticeServiceTest extends IntegrationTest {
     void 공지_삭제() {
         // given
         NoticeCreateRequest createRequest = createNoticeCreateRequest(1);
-        Long noticeId = noticeService.create(createRequest);
+        Long noticeId = noticeService.create(admin.getId(), createRequest);
 
         // when
-        noticeService.delete(noticeId);
+        noticeService.delete(admin.getId(), noticeId);
 
         // then
         Optional<Notice> result = noticeRepository.findById(noticeId);

--- a/src/test/java/com/listywave/notice/application/service/NoticeServiceTest.java
+++ b/src/test/java/com/listywave/notice/application/service/NoticeServiceTest.java
@@ -20,12 +20,19 @@ import com.listywave.notice.application.service.dto.NoticeFindResponse;
 import com.listywave.notice.application.service.dto.NoticeUpdateRequest;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class NoticeServiceTest extends IntegrationTest {
 
-    private final Admin admin = adminRepository.save(new Admin(null, "1.2.3.4", "account", "1234"));
+    private Admin admin;
+
+    @BeforeEach
+    protected void setUp() {
+        super.setUp();
+        admin = adminRepository.save(new Admin(null, "1.2.3.4", "account", "1234"));
+    }
 
     @Test
     void 공지를_생성_후_상세_조회한다() {

--- a/src/test/java/com/listywave/topic/application/service/TopicServiceTest.java
+++ b/src/test/java/com/listywave/topic/application/service/TopicServiceTest.java
@@ -6,6 +6,7 @@ import static com.listywave.list.application.domain.category.CategoryType.MUSIC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.listywave.admin.Admin;
 import com.listywave.common.IntegrationTest;
 import com.listywave.list.application.domain.list.ListDescription;
 import com.listywave.list.application.domain.list.ListTitle;
@@ -16,6 +17,7 @@ import com.listywave.topic.application.service.dto.RecommendTopicFindResponse;
 import com.listywave.topic.application.service.dto.TopicCreateRequest;
 import com.listywave.topic.application.service.dto.TopicFindResponse;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.annotation.Repeat;
@@ -198,6 +200,13 @@ class TopicServiceTest extends IntegrationTest {
     @Nested
     class 관리자용_토픽_조회 {
 
+        private Admin admin;
+
+        @BeforeEach
+        void setUp() {
+            this.admin = adminRepository.save(new Admin(null, "1.2.3.4", "account", "1234"));
+        }
+
         @Test
         void cursorId가_null이고_size가_10일_때_모든_토픽을_조회한다() {
             // given
@@ -219,7 +228,7 @@ class TopicServiceTest extends IntegrationTest {
             topicRepository.saveAll(topics);
 
             // when
-            TopicFindResponse result = topicService.findAll(null, 10);
+            TopicFindResponse result = topicService.findAll(admin.getId(), null, 10);
 
             // then
             assertAll(
@@ -251,7 +260,7 @@ class TopicServiceTest extends IntegrationTest {
             topicRepository.saveAll(topics);
 
             // when
-            TopicFindResponse result = topicService.findAll(topics.get(9).getId(), 10);
+            TopicFindResponse result = topicService.findAll(admin.getId(), topics.get(9).getId(), 10);
 
             // then
             assertAll(
@@ -283,7 +292,7 @@ class TopicServiceTest extends IntegrationTest {
             topicRepository.saveAll(topics);
 
             // when
-            TopicFindResponse result = topicService.findAll(topics.get(4).getId(), 5);
+            TopicFindResponse result = topicService.findAll(admin.getId(), topics.get(4).getId(), 5);
 
             // then
             assertAll(


### PR DESCRIPTION
# Description
Notice와 Topic 관련, 어드민 전용 API에 인증 로직을 적용했습니다.
Controller에서 `@Auth` 를 적용해서 인증 로직을 타도록 했습니다.

인증만하고 끝내기는 심심해서 Notice의 경우에는 `createAdmin`과 `lastUpdateAdmin` 필드를 추가하여 누가 생성하고 마지막으로 수정했는지 기록을 남도록 구현했습니다.

Topic은 관리자의 정보를 저장해도 유용하지 않을 것 같아 그냥 두었습니다.

# Relation Issues
- close #349 
